### PR TITLE
refactor(stack_detector): replace repetitive methods with data-driven rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,8 @@ lib/ocak/
 ├── cli.rb                 # dry-cli registry, maps subcommands to command classes
 ├── commands/              # One class per CLI subcommand (init, run, design, audit, debt, status, clean)
 ├── config.rb              # Loads and validates ocak.yml, provides typed accessors
-├── stack_detector.rb      # Detects project language, framework, test/lint/security tools
+├── stack_detector.rb      # Detects project language, framework, test/lint/security tools via data-driven rules
+├── monorepo_detector.rb   # MonorepoDetector module (included by StackDetector) — npm/pnpm/cargo/go workspace detection
 ├── agent_generator.rb     # Generates agent/skill/hook files from ERB templates, optionally enhanced via claude -p
 ├── pipeline_runner.rb     # Orchestration: poll → plan → worktree → delegate to executor → merge
 ├── pipeline_executor.rb   # Step execution: run_pipeline, execute_step, conditions, cost tracking

--- a/lib/ocak/monorepo_detector.rb
+++ b/lib/ocak/monorepo_detector.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require 'json'
+
+module Ocak
+  module MonorepoDetector
+    private
+
+    def detect_monorepo
+      packages = []
+      packages.concat(detect_npm_workspaces)
+      packages.concat(detect_pnpm_workspaces)
+      packages.concat(detect_cargo_workspaces)
+      packages.concat(detect_go_workspaces)
+      packages.concat(detect_lerna_packages)
+      packages.concat(detect_convention_packages) if packages.empty?
+      packages.uniq!
+      { detected: packages.any?, packages: packages }
+    end
+
+    def detect_npm_workspaces
+      return [] unless exists?('package.json')
+
+      pkg = begin
+        JSON.parse(read_file('package.json'))
+      rescue JSON::ParserError
+        {}
+      end
+      workspaces = pkg['workspaces']
+      workspaces = workspaces['packages'] if workspaces.is_a?(Hash)
+      return [] unless workspaces.is_a?(Array) && workspaces.any?
+
+      expand_workspace_globs(workspaces)
+    end
+
+    def detect_pnpm_workspaces
+      return [] unless exists?('pnpm-workspace.yaml')
+
+      content = read_file('pnpm-workspace.yaml')
+      globs = content.scan(/^\s*-\s*['"]?([^'"#\n]+)/).flatten.map(&:strip)
+      expand_workspace_globs(globs)
+    end
+
+    def detect_cargo_workspaces
+      return [] unless exists?('Cargo.toml') && read_file('Cargo.toml').include?('[workspace]')
+
+      read_file('Cargo.toml').scan(/members\s*=\s*\[(.*?)\]/m).flatten.flat_map do |members|
+        globs = members.scan(/"([^"]+)"/).flatten
+        expand_workspace_globs(globs)
+      end
+    end
+
+    def detect_go_workspaces
+      return [] unless exists?('go.work')
+
+      read_file('go.work').scan(/use\s+(\S+)/).flatten.select do |pkg|
+        Dir.exist?(File.join(@dir, pkg))
+      end
+    end
+
+    def detect_lerna_packages
+      return [] unless exists?('lerna.json')
+
+      lerna = begin
+        JSON.parse(read_file('lerna.json'))
+      rescue JSON::ParserError
+        {}
+      end
+      expand_workspace_globs(lerna['packages'] || ['packages/*'])
+    end
+
+    def detect_convention_packages
+      packages = []
+      %w[packages apps services modules libs].each do |candidate|
+        path = File.join(@dir, candidate)
+        next unless Dir.exist?(path)
+
+        subdirs = Dir.entries(path).reject { |e| e.start_with?('.') }.select do |e|
+          File.directory?(File.join(path, e))
+        end
+        packages.concat(subdirs.map { |s| "#{candidate}/#{s}" }) if subdirs.size > 1
+      end
+      packages
+    end
+
+    def expand_workspace_globs(globs)
+      globs.flat_map do |glob|
+        pattern = File.join(@dir, glob)
+        Dir.glob(pattern).select { |p| File.directory?(p) }.map do |p|
+          p.sub("#{@dir}/", '')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Closes #3

- Replaced five per-language `detect_*_framework` methods with a single `detect_framework` method driven by a `FRAMEWORK_RULES` constant hash
- Replaced large case/if chains in `detect_test_command`, `detect_lint_command`, etc. with a `TOOL_RULES` constant hash and a single `detect_tool(category)` method
- Extracted monorepo detection into a `MonorepoDetector` module included by `StackDetector`, reducing the class from 333 to 200 lines

## Changes

- `lib/ocak/stack_detector.rb` — rewritten with `FRAMEWORK_RULES`, `TOOL_RULES`, and `LANGUAGE_RULES` constants; single iteration methods replace per-language methods
- `lib/ocak/monorepo_detector.rb` — new module extracted from StackDetector handling npm/pnpm/cargo/go workspace detection
- `CLAUDE.md` — updated architecture table to document both files

## Testing

- `bundle exec rspec` — 292 examples, 0 failures
- `bundle exec rubocop` — 55 files inspected, no offenses detected