### PR TITLE
fix(config): standardize agent names to hyphens in default_steps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ lib/ocak/templates/
 - **No heavy dependencies** — stdlib only (open3, json, yaml, erb, fileutils, logger, securerandom) plus dry-cli
 - **ERB templates** use `trim_mode: "-"` for clean output
 - **Config** is always loaded from `ocak.yml` in the project root via `Config.load`
-- Agent names use hyphens in filenames (`security-reviewer.md`) but underscores in Ruby (`security_reviewer`)
+- Agent names use hyphens in filenames (`security-reviewer.md`) and in `ocak.yml` step definitions (`security-reviewer`); Ruby identifiers use underscores. `pipeline_executor.rb` converts underscores to hyphens for backwards compatibility with existing user configs.
 - All external commands (git, gh, claude) go through `Open3.capture3` or `Open3.popen3`
 
 ## Key Patterns

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ steps:
   - agent: reviewer
     role: verify
     condition: had_fixes        # Only runs if fixes were made
-  - agent: security_reviewer
+  - agent: security-reviewer
     role: security
   - agent: implementer
     role: fix

--- a/lib/ocak/config.rb
+++ b/lib/ocak/config.rb
@@ -102,7 +102,7 @@ module Ocak
         { agent: 'reviewer', role: 'review' },
         { agent: 'implementer', role: 'fix', condition: 'has_findings' },
         { agent: 'reviewer', role: 'verify', condition: 'had_fixes' },
-        { agent: 'security_reviewer', role: 'security' },
+        { agent: 'security-reviewer', role: 'security' },
         { agent: 'implementer', role: 'fix', condition: 'has_findings', complexity: 'full' },
         { agent: 'documenter', role: 'document', complexity: 'full' },
         { agent: 'auditor', role: 'audit', complexity: 'full' },

--- a/spec/ocak/pipeline_runner_spec.rb
+++ b/spec/ocak/pipeline_runner_spec.rb
@@ -169,7 +169,7 @@ RSpec.describe Ocak::PipelineRunner do
       [
         { 'agent' => 'implementer', 'role' => 'implement' },
         { 'agent' => 'reviewer', 'role' => 'review' },
-        { 'agent' => 'security_reviewer', 'role' => 'security' },
+        { 'agent' => 'security-reviewer', 'role' => 'security' },
         { 'agent' => 'documenter', 'role' => 'document', 'complexity' => 'full' },
         { 'agent' => 'auditor', 'role' => 'audit', 'complexity' => 'full' },
         { 'agent' => 'merger', 'role' => 'merge' }


### PR DESCRIPTION
## Summary

Closes #21

- Changed `security_reviewer` → `security-reviewer` in `config.rb` `default_steps` to match the hyphen convention used everywhere else in the codebase
- Updated README example and CLAUDE.md conventions note to reflect the correct naming
- The `tr('_', '-')` call in `pipeline_executor.rb` is retained for backwards compatibility with existing user configs that may still use underscores

## Changes

- `lib/ocak/config.rb` — `default_steps`: `security_reviewer` → `security-reviewer`
- `README.md` — example step config updated to use hyphen
- `CLAUDE.md` — conventions note clarified to describe actual behavior
- `spec/ocak/pipeline_runner_spec.rb` — expectation updated to match hyphen name

## Testing

- `bundle exec rspec` — passed
- `bundle exec rubocop` — passed