### PR TITLE
refactor(runner): move FailedStatus from ClaudeRunner to ProcessRunner

### DIFF
--- a/lib/ocak/claude_runner.rb
+++ b/lib/ocak/claude_runner.rb
@@ -14,9 +14,8 @@ module Ocak
       def warnings?          = output.to_s.include?("\u{1F7E1}")
     end
 
-    FailedStatus = Struct.new(:success?) do
-      def self.instance = new(false)
-    end
+    # Backwards-compat alias — FailedStatus now lives in ProcessRunner.
+    FailedStatus = ProcessRunner::FailedStatus
 
     AGENT_TOOLS = {
       'implementer' => 'Read,Write,Edit,Glob,Grep,Bash',

--- a/lib/ocak/process_runner.rb
+++ b/lib/ocak/process_runner.rb
@@ -5,6 +5,10 @@ require 'open3'
 module Ocak
   # Runs a subprocess with streaming line output and timeout support.
   module ProcessRunner
+    FailedStatus = Struct.new(:success?) do
+      def self.instance = new(false)
+    end
+
     module_function
 
     def run(cmd, chdir:, timeout: nil, on_line: nil)
@@ -25,7 +29,7 @@ module Ocak
         [stdout, stderr, wait_thr.value]
       end
     rescue Errno::ENOENT => e
-      ['', e.message, ClaudeRunner::FailedStatus.instance]
+      ['', e.message, FailedStatus.instance]
     end
 
     def read_streams(out, err, ctx)

--- a/spec/ocak/claude_runner_spec.rb
+++ b/spec/ocak/claude_runner_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe Ocak::ClaudeRunner do
 
     it 'reports failure on non-zero exit' do
       allow(Ocak::ProcessRunner).to receive(:run)
-        .and_return(['', 'error', Ocak::ClaudeRunner::FailedStatus.instance])
+        .and_return(['', 'error', Ocak::ProcessRunner::FailedStatus.instance])
 
       result = runner.run_prompt('Analyze this')
       expect(result.success?).to be false
@@ -213,12 +213,6 @@ RSpec.describe Ocak::ClaudeRunner do
       result = runner.run_agent('reviewer', 'Review code')
       expect(result.success?).to be false
       expect(call_count).to eq(3) # initial + 2 retries
-    end
-  end
-
-  describe 'FailedStatus' do
-    it 'reports not success' do
-      expect(described_class::FailedStatus.instance.success?).to be false
     end
   end
 end

--- a/spec/ocak/process_runner_spec.rb
+++ b/spec/ocak/process_runner_spec.rb
@@ -2,7 +2,6 @@
 
 require 'spec_helper'
 require 'ocak/process_runner'
-require 'ocak/claude_runner'
 
 RSpec.describe Ocak::ProcessRunner do
   describe '.run' do
@@ -104,6 +103,12 @@ RSpec.describe Ocak::ProcessRunner do
       stdout_r.close unless stdout_r.closed?
       stdout_w.close unless stdout_w.closed?
       stderr_r.close unless stderr_r.closed?
+    end
+  end
+
+  describe 'FailedStatus' do
+    it 'reports not success' do
+      expect(described_class::FailedStatus.instance.success?).to be false
     end
   end
 end


### PR DESCRIPTION
## Summary

Closes #20

- Moved `FailedStatus` struct from `ClaudeRunner` into `ProcessRunner` so it lives alongside the code that uses it
- Added a `FailedStatus = ProcessRunner::FailedStatus` alias in `ClaudeRunner` for backwards compatibility
- Updated specs to reference `ProcessRunner::FailedStatus` directly; moved the `FailedStatus` unit test to `process_runner_spec.rb`

## Changes

- `lib/ocak/process_runner.rb` — defines `FailedStatus` struct here instead of depending on `ClaudeRunner`
- `lib/ocak/claude_runner.rb` — replaces the struct definition with a backwards-compat alias
- `spec/ocak/process_runner_spec.rb` — removes the `require 'ocak/claude_runner'` dependency; adds `FailedStatus` spec
- `spec/ocak/claude_runner_spec.rb` — updates reference to `ProcessRunner::FailedStatus`; removes duplicate `FailedStatus` spec

## Testing

- `bundle exec rspec` — passed (21 examples, 0 failures)