### PR TITLE
refactor(merge): route all GitHub issue fetches through IssueFetcher

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ lib/ocak/
 ├── pipeline_runner.rb     # Orchestration: poll → plan → worktree → delegate to executor → merge
 ├── pipeline_executor.rb   # Step execution: run_pipeline, execute_step, conditions, cost tracking, progress comments
 ├── claude_runner.rb       # Wraps `claude -p` with stream-json parsing (StreamParser, AgentResult)
-├── issue_fetcher.rb       # GitHub CLI wrapper for issue listing, labeling, commenting, label creation
+├── issue_fetcher.rb       # GitHub CLI wrapper for all issue data access — listing, labeling, commenting, label creation, view
 ├── worktree_manager.rb    # Git worktree create/remove/list/clean
 ├── merge_manager.rb       # Sequential rebase + test + push, then delegates to merger agent
 ├── planner.rb             # Batch planning: groups issues for parallel/sequential execution
@@ -53,6 +53,9 @@ Each step in `ocak.yml` has an `agent`, `role`, and optional `condition`. Condit
 
 ### Worktree Isolation
 Parallel issues get separate git worktrees under `.claude/worktrees/`. After all pipeline steps complete, worktrees are rebased onto main, tested, pushed, and the merger agent creates+merges the PR.
+
+### Issue Data Access
+All GitHub issue data fetching goes through `IssueFetcher#view`. Classes that need issue data receive an `IssueFetcher` instance via constructor injection (`issues:` keyword param) rather than calling `gh` directly.
 
 ## Development
 

--- a/lib/ocak/commands/resume.rb
+++ b/lib/ocak/commands/resume.rb
@@ -84,7 +84,7 @@ module Ocak
 
       def attempt_merge(ctx)
         merger = MergeManager.new(config: ctx[:config], claude: ctx[:claude],
-                                  logger: ctx[:logger], watch: ctx[:watch])
+                                  logger: ctx[:logger], issues: ctx[:issues], watch: ctx[:watch])
         worktree = WorktreeManager::Worktree.new(
           path: ctx[:chdir], branch: ctx[:saved][:branch], issue_number: ctx[:issue_number]
         )

--- a/lib/ocak/pipeline_runner.rb
+++ b/lib/ocak/pipeline_runner.rb
@@ -135,7 +135,7 @@ module Ocak
       results = threads.map(&:value)
 
       merger = MergeManager.new(
-        config: @config, claude: build_claude(logger), logger: logger, watch: @watch_formatter
+        config: @config, claude: build_claude(logger), logger: logger, issues: issues, watch: @watch_formatter
       )
       results.select { |r| r[:success] }.each do |result|
         merge_completed_issue(result, merger: merger, issues: issues, logger: logger)

--- a/lib/ocak/reready_processor.rb
+++ b/lib/ocak/reready_processor.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'open3'
-require 'json'
 
 module Ocak
   class RereadyProcessor
@@ -50,14 +49,7 @@ module Ocak
     end
 
     def fetch_issue(issue_number)
-      stdout, _, status = Open3.capture3('gh', 'issue', 'view', issue_number.to_s,
-                                         '--json', 'title,body',
-                                         chdir: @config.project_dir)
-      return nil unless status.success?
-
-      JSON.parse(stdout)
-    rescue JSON::ParserError
-      nil
+      @issues.view(issue_number, fields: 'title,body')
     end
 
     def checkout_pr_branch(branch_name)

--- a/spec/ocak/reready_processor_spec.rb
+++ b/spec/ocak/reready_processor_spec.rb
@@ -62,9 +62,9 @@ RSpec.describe Ocak::RereadyProcessor do
       before do
         allow(issues).to receive(:extract_issue_number_from_pr).and_return(42)
         allow(issues).to receive(:fetch_pr_comments).and_return({ comments: [], reviews: [] })
-        allow(Open3).to receive(:capture3)
-          .with('gh', 'issue', 'view', '42', '--json', 'title,body', chdir: '/project')
-          .and_return(['', 'not found', failure_status])
+        allow(issues).to receive(:view)
+          .with(42, fields: 'title,body')
+          .and_return(nil)
       end
 
       it 'returns false' do
@@ -76,9 +76,9 @@ RSpec.describe Ocak::RereadyProcessor do
       before do
         allow(issues).to receive(:extract_issue_number_from_pr).and_return(42)
         allow(issues).to receive(:fetch_pr_comments).and_return({ comments: [], reviews: [] })
-        allow(Open3).to receive(:capture3)
-          .with('gh', 'issue', 'view', '42', '--json', 'title,body', chdir: '/project')
-          .and_return([JSON.generate({ 'title' => 'Fix bug', 'body' => 'desc' }), '', success_status])
+        allow(issues).to receive(:view)
+          .with(42, fields: 'title,body')
+          .and_return({ 'title' => 'Fix bug', 'body' => 'desc' })
 
         allow(Open3).to receive(:capture3)
           .with('git', 'fetch', 'origin', 'auto/issue-42-abc123', chdir: '/project')
@@ -99,9 +99,9 @@ RSpec.describe Ocak::RereadyProcessor do
                                                                                'body' => 'fix this' }],
                                                                   reviews: []
                                                                 })
-        allow(Open3).to receive(:capture3)
-          .with('gh', 'issue', 'view', '42', '--json', 'title,body', chdir: '/project')
-          .and_return([JSON.generate({ 'title' => 'Fix bug', 'body' => 'desc' }), '', success_status])
+        allow(issues).to receive(:view)
+          .with(42, fields: 'title,body')
+          .and_return({ 'title' => 'Fix bug', 'body' => 'desc' })
 
         # Checkout
         allow(Open3).to receive(:capture3)
@@ -166,9 +166,9 @@ RSpec.describe Ocak::RereadyProcessor do
       before do
         allow(issues).to receive(:extract_issue_number_from_pr).and_return(42)
         allow(issues).to receive(:fetch_pr_comments).and_return({ comments: [], reviews: [] })
-        allow(Open3).to receive(:capture3)
-          .with('gh', 'issue', 'view', '42', '--json', 'title,body', chdir: '/project')
-          .and_return([JSON.generate({ 'title' => 'Fix bug', 'body' => 'desc' }), '', success_status])
+        allow(issues).to receive(:view)
+          .with(42, fields: 'title,body')
+          .and_return({ 'title' => 'Fix bug', 'body' => 'desc' })
 
         # Checkout succeeds
         allow(Open3).to receive(:capture3)


### PR DESCRIPTION
## Summary

Closes #19

- Inject `IssueFetcher` into `MergeManager` and `RereadyProcessor` via `issues:` constructor param
- Replace direct `gh issue view` calls in `fetch_issue_title` and `fetch_issue` with `@issues.view(...)`
- Remove duplicate JSON parsing and inconsistent error handling from both classes

## Changes

- `lib/ocak/merge_manager.rb` — add `issues:` param, delegate `fetch_issue_title` to `@issues.view`
- `lib/ocak/reready_processor.rb` — delegate `fetch_issue` to `@issues.view`, drop `require 'json'`
- `lib/ocak/pipeline_runner.rb` — pass `issues:` when constructing `MergeManager`
- `lib/ocak/commands/resume.rb` — pass `issues:` when constructing `MergeManager`
- `CLAUDE.md` — document `IssueFetcher` as the single point of issue data access
- `spec/ocak/merge_manager_spec.rb` — mock `IssueFetcher` instead of `Open3`
- `spec/ocak/reready_processor_spec.rb` — mock `IssueFetcher` instead of `Open3`

## Testing

- `bundle exec rspec` — passed (365 examples, 0 failures)