### PR TITLE
feat(config): raise max_parallel to 5 and relax planner conflict rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ stack:
 
 # Pipeline settings
 pipeline:
-  max_parallel: 3        # Concurrent worktrees
+  max_parallel: 5        # Concurrent worktrees
   poll_interval: 60      # Seconds between polls
   worktree_dir: ".claude/worktrees"
   log_dir: "logs/pipeline"
@@ -229,7 +229,7 @@ ocak run [options]                Run the pipeline
   --single N                      Run one issue, no worktrees
   --dry-run                       Show plan without executing
   --once                          Process current batch and exit
-  --max-parallel N                Limit concurrency (default: 3)
+  --max-parallel N                Limit concurrency (default: 5)
   --poll-interval N               Seconds between polls (default: 60)
 ocak resume N [--watch]           Resume a failed pipeline from last successful step
 ocak hiz N [--watch]              Fast-mode: Sonnet-only implement+review+security, creates PR (no merge)

--- a/lib/ocak/agent_generator.rb
+++ b/lib/ocak/agent_generator.rb
@@ -89,6 +89,7 @@ module Ocak
       monorepo = @stack.respond_to?(:monorepo) ? @stack.monorepo : false
       packages = @stack.respond_to?(:packages) ? (@stack.packages || []) : []
       project_dir = @project_dir
+      max_parallel = 5
 
       binding
     end

--- a/lib/ocak/config.rb
+++ b/lib/ocak/config.rb
@@ -47,7 +47,7 @@ module Ocak
     end
 
     # Pipeline
-    def max_parallel  = @overrides[:max_parallel] || dig(:pipeline, :max_parallel) || 3
+    def max_parallel  = @overrides[:max_parallel] || dig(:pipeline, :max_parallel) || 5
     def poll_interval = @overrides[:poll_interval] || dig(:pipeline, :poll_interval) || 60
     def worktree_dir  = dig(:pipeline, :worktree_dir) || '.claude/worktrees'
     def log_dir       = dig(:pipeline, :log_dir) || 'logs/pipeline'

--- a/lib/ocak/templates/agents/planner.md.erb
+++ b/lib/ocak/templates/agents/planner.md.erb
@@ -37,14 +37,17 @@ For each issue, determine:
 
 Two issues CANNOT be parallelized if they:
 
-- Touch the same files
 - Both require database migrations (timestamp/ordering conflicts)
-- Both modify shared base classes or utilities
-- Both modify the same routes or configuration
 - Have an explicit dependency (issue A depends on issue B)
-- Both modify test fixtures or factories
 
-Two issues CAN be parallelized if they:
+Two issues CAN be parallelized even if they:
+
+- Touch the same files (the merge step handles rebase conflicts automatically)
+- Both modify shared base classes or utilities
+- Both modify test fixtures or factories
+- Both modify the same routes or configuration
+
+Two issues are IDEAL for parallelization if they:
 
 - Touch completely different areas of the codebase
 - Modify different modules/namespaces with no overlap
@@ -79,8 +82,8 @@ Return valid JSON (no markdown, no code fences):
 
 ### Rules
 
-- Maximum <%= "3" %> issues per batch
-- When in doubt, serialize — false negatives (missed parallelism) are safer than false positives (merge conflicts)
+- Maximum <%= max_parallel %> issues per batch
+- When in doubt, parallelize — the merge step handles rebase conflicts automatically
 - Issues with migrations always go in separate batches unless they touch completely different schemas
 - If only one issue exists, output a single batch with one issue
 - When in doubt about complexity, use `"full"` — it's safer to run extra steps than to skip needed ones

--- a/lib/ocak/templates/ocak.yml.erb
+++ b/lib/ocak/templates/ocak.yml.erb
@@ -28,7 +28,7 @@ stack:
 
 # Pipeline settings
 pipeline:
-  max_parallel: 3
+  max_parallel: 5
   poll_interval: 60
   worktree_dir: ".claude/worktrees"
   log_dir: "logs/pipeline"

--- a/spec/ocak/config_spec.rb
+++ b/spec/ocak/config_spec.rb
@@ -96,8 +96,8 @@ RSpec.describe Ocak::Config do
   describe 'pipeline defaults' do
     subject(:config) { described_class.new({}, dir) }
 
-    it 'defaults max_parallel to 3' do
-      expect(config.max_parallel).to eq(3)
+    it 'defaults max_parallel to 5' do
+      expect(config.max_parallel).to eq(5)
     end
 
     it 'defaults poll_interval to 60' do


### PR DESCRIPTION
## Summary

Closes #27

- Raise `max_parallel` default from 3 to 5 across `Config`, `ocak.yml.erb`, and README
- Expose `max_parallel` in `AgentGenerator#template_binding` so the planner template can reference it dynamically
- Relax planner conflict rules: file overlap is no longer a hard blocker (rebase handles it); only database migrations and explicit issue dependencies block parallelization
- Change planner guidance from "when in doubt, serialize" to "when in doubt, parallelize"

## Changes

- `lib/ocak/config.rb` — change `|| 3` to `|| 5` for `max_parallel` default
- `lib/ocak/templates/ocak.yml.erb` — generated config now shows `max_parallel: 5`
- `lib/ocak/agent_generator.rb` — add `max_parallel = 5` to `template_binding`
- `lib/ocak/templates/agents/planner.md.erb` — use `<%= max_parallel %>` instead of hardcoded `"3"`; update conflict rules and guidance
- `README.md` — update documentation examples to show default of 5
- `spec/ocak/config_spec.rb` — update `max_parallel` default test to expect `5`

## Testing

- `bundle exec rspec` — passed (378 examples, 0 failures)
- `bundle exec rubocop` — passed (61 files, no offenses)