### PR TITLE
feat(hiz): parallel reviews with per-step model selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ ocak run [options]                Run the pipeline
   --max-parallel N                Limit concurrency (default: 5)
   --poll-interval N               Seconds between polls (default: 60)
 ocak resume N [--watch]           Resume a failed pipeline from last successful step
-ocak hiz N [--watch]              Fast-mode: Sonnet-only implement+review+security, creates PR (no merge)
+ocak hiz N [--watch]              Fast-mode: implement (sonnet) + parallel review (haiku) + security (sonnet), creates PR (no merge)
 ocak status                       Show pipeline state
 ocak clean                        Remove stale worktrees
 ocak design [description]         Launch issue design session
@@ -244,7 +244,7 @@ ocak debt                         Track technical debt
 
 **What's `ocak hiz`?**
 
-Fast mode. Runs implement + review + security using Sonnet instead of Opus, creates a PR but doesn't merge it. Good for simple issues where you want a quick PR to review yourself. Roughly 5-10x cheaper than the full pipeline.
+Fast mode. Runs implement (sonnet), then reviewer (haiku) and security-reviewer (sonnet) in parallel, and creates a PR without merging. Good for simple issues where you want a quick PR to review yourself. Roughly 5-10x cheaper than the full pipeline.
 
 ```bash
 ocak hiz 42 --watch


### PR DESCRIPTION
## Summary

Closes #25

- Run `reviewer` (haiku) and `security-reviewer` (sonnet) concurrently after implementation, reducing review wall-clock time to `max(review, security)` instead of `review + security`
- Replace single `MODEL = 'sonnet'` constant with per-step `STEP_MODELS` hash
- Thread exceptions are caught and logged without crashing the pipeline

## Changes

- `lib/ocak/commands/hiz.rb` — replace sequential `STEPS` loop with parallel `run_reviews_in_parallel` using `Thread.new` + `.value`; add `STEP_MODELS` for per-agent model selection
- `spec/ocak/commands/hiz_spec.rb` — update model expectations to haiku for reviewer; add thread exception handling test and parallel invocation test
- `README.md` — update `hiz` description to reflect parallel reviews and per-step models

## Testing

- `bundle exec rspec spec/ocak/commands/hiz_spec.rb` — 16 examples, 0 failures