### PR TITLE
feat(pipeline): add informative comments for start, skips, retries, and summary

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,9 @@ Parallel issues get separate git worktrees under `.claude/worktrees/`. After all
 ### Issue Data Access
 All GitHub issue data fetching goes through `IssueFetcher#view`. Classes that need issue data receive an `IssueFetcher` instance via constructor injection (`issues:` keyword param) rather than calling `gh` directly.
 
+### Pipeline Comments
+Both `pipeline_executor.rb` and `hiz.rb` post GitHub comments at pipeline start, per-step completion, skip events, retry warnings, and pipeline summary. Always use `post_step_comment` (wraps `@issues&.comment` with `rescue StandardError => nil`) so comment failures never crash the pipeline. Emoji vocabulary: 🚀 start, 🔄 in-progress, ✅ success, ❌ failure, ⏭️ skip, ⚠️ warning.
+
 ## Development
 
 ```bash

--- a/spec/ocak/commands/hiz_spec.rb
+++ b/spec/ocak/commands/hiz_spec.rb
@@ -330,6 +330,129 @@ RSpec.describe Ocak::Commands::Hiz do
     end
   end
 
+  describe 'pipeline comments' do
+    before do
+      allow(claude).to receive(:run_agent).and_return(success_result)
+      allow(issues).to receive(:view).with(42).and_return({ 'title' => 'Test', 'number' => 42 })
+      allow(Open3).to receive(:capture3)
+        .with('gh', 'pr', 'create', '--title', anything, '--body', anything,
+              '--head', anything, chdir: '/project')
+        .and_return(["https://github.com/org/repo/pull/1\n", '', success_status])
+    end
+
+    it 'posts hiz start comment' do
+      command.call(issue: '42')
+
+      expect(issues).to have_received(:comment)
+        .with(42, /\u{1F680} \*\*Hiz \(fast mode\) started\*\*.*implement.*review.*security/)
+    end
+
+    it 'includes verify in start comment when test_command is configured' do
+      allow(config).to receive(:test_command).and_return('bundle exec rspec')
+      allow(Open3).to receive(:capture3)
+        .with('bundle', 'exec', 'rspec', chdir: '/project')
+        .and_return(['', '', success_status])
+
+      command.call(issue: '42')
+
+      expect(issues).to have_received(:comment)
+        .with(42, /\*\*Hiz \(fast mode\) started\*\*.*verify/)
+    end
+
+    it 'posts step start comment for each step' do
+      command.call(issue: '42')
+
+      expect(issues).to have_received(:comment)
+        .with(42, /\u{1F504} \*\*Phase: implement\*\*/)
+      expect(issues).to have_received(:comment)
+        .with(42, /\u{1F504} \*\*Phase: review\*\*/)
+      expect(issues).to have_received(:comment)
+        .with(42, /\u{1F504} \*\*Phase: security\*\*/)
+    end
+
+    it 'posts step completion comments' do
+      command.call(issue: '42')
+
+      expect(issues).to have_received(:comment)
+        .with(42, /\u{2705} \*\*Phase: implement\*\* completed/)
+      expect(issues).to have_received(:comment)
+        .with(42, /\u{2705} \*\*Phase: review\*\* completed/)
+      expect(issues).to have_received(:comment)
+        .with(42, /\u{2705} \*\*Phase: security\*\* completed/)
+    end
+
+    it 'posts success summary comment' do
+      command.call(issue: '42')
+
+      expect(issues).to have_received(:comment)
+        .with(42, %r{\u{2705} \*\*Pipeline complete\*\*.*3/3 steps run.*0 skipped})
+    end
+
+    it 'posts failure summary when implementation fails' do
+      allow(claude).to receive(:run_agent)
+        .with('implementer', anything, chdir: '/project', model: 'sonnet')
+        .and_return(failure_result)
+
+      command.call(issue: '42')
+
+      expect(issues).to have_received(:comment)
+        .with(42, %r{\u{274C} \*\*Pipeline failed\*\* at phase: implement.*1/3 steps completed})
+    end
+
+    it 'does not crash when comment posting fails' do
+      allow(issues).to receive(:comment).and_raise(StandardError, 'network error')
+
+      expect { command.call(issue: '42') }.not_to raise_error
+    end
+  end
+
+  describe 'hiz retry comment' do
+    before do
+      allow(config).to receive(:test_command).and_return('bundle exec rspec')
+      allow(claude).to receive(:run_agent).and_return(success_result)
+    end
+
+    it 'posts retry warning when final verification fails' do
+      allow(Open3).to receive(:capture3)
+        .with('bundle', 'exec', 'rspec', chdir: '/project')
+        .and_return(['FAIL', '', failure_status])
+
+      command.call(issue: '42')
+
+      expect(issues).to have_received(:comment)
+        .with(42, /\u{26A0}.*\*\*Final verification failed\*\*.*attempting auto-fix/)
+    end
+
+    it 'posts final-verify start and failure comments' do
+      allow(Open3).to receive(:capture3)
+        .with('bundle', 'exec', 'rspec', chdir: '/project')
+        .and_return(['FAIL', '', failure_status])
+
+      command.call(issue: '42')
+
+      expect(issues).to have_received(:comment)
+        .with(42, /\u{1F504} \*\*Phase: final-verify\*\*/)
+      expect(issues).to have_received(:comment)
+        .with(42, /\u{274C} \*\*Phase: final-verify\*\* failed/)
+    end
+
+    it 'posts final-verify completion on success' do
+      allow(Open3).to receive(:capture3)
+        .with('bundle', 'exec', 'rspec', chdir: '/project')
+        .and_return(['', '', success_status])
+      allow(issues).to receive(:view).with(42).and_return(nil)
+      allow(Open3).to receive(:capture3)
+        .with('gh', 'pr', 'create', '--title', anything, '--body', anything,
+              '--head', anything, chdir: '/project')
+        .and_return(["https://github.com/org/repo/pull/1\n", '', success_status])
+
+      command.call(issue: '42')
+
+      expect(issues).to have_received(:comment)
+        .with(42, /\u{2705} \*\*Phase: final-verify\*\* completed/)
+    end
+  end
+
   it 'exits with error on ConfigNotFound' do
     allow(Ocak::Config).to receive(:load).and_raise(Ocak::Config::ConfigNotFound, 'not found')
 


### PR DESCRIPTION
## Summary

Closes #34

- Adds pipeline start comment with complexity classification and step count (including conditional step count) to both `pipeline_executor.rb` and `hiz.rb`
- Posts skip-reason comments when steps are skipped (no blocking findings, fast-track, manual review, no fixes made)
- Posts retry warning comment when final verification fails and triggers auto-fix attempt
- Posts pipeline completion summary with steps run/skipped, total cost, and total duration on both success and failure paths

## Changes

- `CLAUDE.md` — documents the Pipeline Comments pattern and emoji vocabulary convention
- `lib/ocak/pipeline_executor.rb` — adds `post_pipeline_start_comment`, `post_retry_comment`, `post_pipeline_summary_comment`; wires skip-reason comments into `run_pipeline_steps`; tracks start time and step counts throughout `run_pipeline`
- `lib/ocak/commands/hiz.rb` — adds `@issues` wiring, start/per-step/skip/retry/summary comments matching the same patterns as the executor
- `spec/ocak/pipeline_executor_spec.rb` — tests for pipeline start, each skip reason, retry warning, and summary comments (success and failure)
- `spec/ocak/commands/hiz_spec.rb` — tests for hiz start, step, skip, retry, and summary comments; nil-issues safety

## Testing

- `bundle exec rspec` — passed (429 examples, 0 failures)
- `bundle exec rubocop` — passed