### PR TITLE
feat(cli): add audit and debt subcommands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ A Ruby gem that sets up and runs a multi-agent pipeline for autonomous GitHub is
 ```
 lib/ocak/
 ├── cli.rb                 # dry-cli registry, maps subcommands to command classes
-├── commands/              # One class per CLI subcommand (init, run, resume, hiz, design, status, clean)
+├── commands/              # One class per CLI subcommand (init, run, resume, hiz, design, audit, debt, status, clean)
 ├── config.rb              # Loads and validates ocak.yml, provides typed accessors
 ├── stack_detector.rb      # Detects project language, framework, test/lint/security tools via data-driven rules
 ├── monorepo_detector.rb   # MonorepoDetector module (included by StackDetector) — npm/pnpm/cargo/go workspace detection

--- a/lib/ocak/cli.rb
+++ b/lib/ocak/cli.rb
@@ -4,6 +4,8 @@ require 'dry/cli'
 require_relative 'commands/init'
 require_relative 'commands/run'
 require_relative 'commands/design'
+require_relative 'commands/audit'
+require_relative 'commands/debt'
 require_relative 'commands/status'
 require_relative 'commands/clean'
 require_relative 'commands/resume'
@@ -17,6 +19,8 @@ module Ocak
       register 'init',   Ocak::Commands::Init
       register 'run',    Ocak::Commands::Run
       register 'design', Ocak::Commands::Design
+      register 'audit',  Ocak::Commands::Audit
+      register 'debt',   Ocak::Commands::Debt
       register 'status', Ocak::Commands::Status
       register 'clean',  Ocak::Commands::Clean
       register 'resume', Ocak::Commands::Resume

--- a/lib/ocak/commands/audit.rb
+++ b/lib/ocak/commands/audit.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Ocak
+  module Commands
+    class Audit < Dry::CLI::Command
+      desc 'Run codebase audit'
+
+      argument :scope, type: :string, required: false,
+                       desc: 'Audit scope: security, tests, patterns, debt, dependencies, or all'
+
+      def call(scope: nil, **)
+        skill_path = File.join(Dir.pwd, '.claude', 'skills', 'audit', 'SKILL.md')
+
+        unless File.exist?(skill_path)
+          warn 'No audit skill found. Run `ocak init` first.'
+          exit 1
+        end
+
+        puts "Starting audit#{" (scope: #{scope})" if scope}..."
+        puts 'Run this inside Claude Code:'
+        puts "  /audit#{" #{scope}" if scope}"
+      end
+    end
+  end
+end

--- a/lib/ocak/commands/debt.rb
+++ b/lib/ocak/commands/debt.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Ocak
+  module Commands
+    class Debt < Dry::CLI::Command
+      desc 'Track technical debt'
+
+      def call(**)
+        skill_path = File.join(Dir.pwd, '.claude', 'skills', 'debt', 'SKILL.md')
+
+        unless File.exist?(skill_path)
+          warn 'No debt skill found. Run `ocak init` first.'
+          exit 1
+        end
+
+        puts 'Run this inside Claude Code:'
+        puts '  /debt'
+      end
+    end
+  end
+end

--- a/spec/ocak/cli_spec.rb
+++ b/spec/ocak/cli_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Ocak::CLI do
   describe 'command registration' do
     let(:registry) { Ocak::CLI::Commands }
 
-    %w[init run design status clean resume hiz].each do |cmd_name|
+    %w[init run design audit debt status clean resume hiz].each do |cmd_name|
       it "registers the #{cmd_name} command" do
         command_class = Ocak::Commands.const_get(cmd_name.capitalize)
         expect(command_class).to be < Dry::CLI::Command

--- a/spec/ocak/commands/audit_spec.rb
+++ b/spec/ocak/commands/audit_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'dry/cli'
+require 'tmpdir'
+require 'ocak/commands/audit'
+
+RSpec.describe Ocak::Commands::Audit do
+  subject(:command) { described_class.new }
+
+  let(:dir) { Dir.mktmpdir }
+
+  before do
+    allow(Dir).to receive(:pwd).and_return(dir)
+  end
+
+  after { FileUtils.remove_entry(dir) }
+
+  it 'prints usage when skill file exists' do
+    skill_dir = File.join(dir, '.claude', 'skills', 'audit')
+    FileUtils.mkdir_p(skill_dir)
+    File.write(File.join(skill_dir, 'SKILL.md'), '# Audit')
+
+    expect { command.call }.to output(/Run this inside Claude Code/).to_stdout
+  end
+
+  it 'includes scope in output when provided' do
+    skill_dir = File.join(dir, '.claude', 'skills', 'audit')
+    FileUtils.mkdir_p(skill_dir)
+    File.write(File.join(skill_dir, 'SKILL.md'), '# Audit')
+
+    expect { command.call(scope: 'security') }.to output(/scope: security/).to_stdout
+  end
+
+  it 'exits with error when skill file missing' do
+    expect { command.call }.to raise_error(SystemExit)
+  end
+end

--- a/spec/ocak/commands/debt_spec.rb
+++ b/spec/ocak/commands/debt_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'dry/cli'
+require 'tmpdir'
+require 'ocak/commands/debt'
+
+RSpec.describe Ocak::Commands::Debt do
+  subject(:command) { described_class.new }
+
+  let(:dir) { Dir.mktmpdir }
+
+  before do
+    allow(Dir).to receive(:pwd).and_return(dir)
+  end
+
+  after { FileUtils.remove_entry(dir) }
+
+  it 'prints usage when skill file exists' do
+    skill_dir = File.join(dir, '.claude', 'skills', 'debt')
+    FileUtils.mkdir_p(skill_dir)
+    File.write(File.join(skill_dir, 'SKILL.md'), '# Debt')
+
+    expect { command.call }.to output(/Run this inside Claude Code/).to_stdout
+  end
+
+  it 'exits with error when skill file missing' do
+    expect { command.call }.to raise_error(SystemExit)
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `ocak audit [scope]` CLI subcommand that guides users to run the `/audit` skill inside Claude Code
- Adds `ocak debt` CLI subcommand that guides users to run the `/debt` skill inside Claude Code
- Registers both new commands in the CLI registry (`cli.rb`)

## Changes

- `lib/ocak/cli.rb` — registers `audit` and `debt` commands
- `lib/ocak/commands/audit.rb` — new `Audit` command with optional scope argument
- `lib/ocak/commands/debt.rb` — new `Debt` command
- `spec/ocak/cli_spec.rb` — updates CLI spec
- `spec/ocak/commands/audit_spec.rb` — new specs for audit command
- `spec/ocak/commands/debt_spec.rb` — new specs for debt command

## Testing

- `bundle exec rspec` — passed
- `bundle exec rubocop` — passed