### PR TITLE
feat(logging): add full agent output sidecar files and richer tool call logging

### DIFF
--- a/lib/ocak/claude_runner.rb
+++ b/lib/ocak/claude_runner.rb
@@ -119,7 +119,8 @@ module Ocak
     end
 
     def build_agent_result(parser, status, stderr, agent_name)
-      output = parser.result_text || ''
+      full = parser.full_output
+      output = full.empty? ? (parser.result_text || '') : full
       exit_ok = status.respond_to?(:success?) && status.success?
       success = parser.success? && exit_ok
 

--- a/lib/ocak/planner.rb
+++ b/lib/ocak/planner.rb
@@ -17,7 +17,7 @@ module Ocak
 
     def build_step_prompt(role, issue_number, review_output)
       if role == 'fix'
-        "Fix these review findings for issue ##{issue_number}:\n\n#{review_output}"
+        "Fix these review findings for issue ##{issue_number}:\n\n<review_output>\n#{review_output}\n</review_output>"
       elsif STEP_PROMPTS.key?(role)
         format(STEP_PROMPTS[role], issue: issue_number)
       else

--- a/lib/ocak/templates/gitignore_additions.txt
+++ b/lib/ocak/templates/gitignore_additions.txt
@@ -8,3 +8,4 @@
 
 # Ocak pipeline
 logs/pipeline/
+.ocak/logs/

--- a/spec/ocak/planner_spec.rb
+++ b/spec/ocak/planner_spec.rb
@@ -9,10 +9,10 @@ RSpec.describe Ocak::Planner do
   end
 
   describe '#build_step_prompt' do
-    it 'returns fix prompt with review output for fix role' do
+    it 'returns fix prompt with review output wrapped in XML tags for fix role' do
       prompt = host.build_step_prompt('fix', 42, 'Found bugs')
 
-      expect(prompt).to eq("Fix these review findings for issue #42:\n\nFound bugs")
+      expect(prompt).to eq("Fix these review findings for issue #42:\n\n<review_output>\nFound bugs\n</review_output>")
     end
 
     it 'returns formatted prompt for known roles' do


### PR DESCRIPTION
## Summary

Closes #47

- After each pipeline step, the full untruncated agent output is written to `.ocak/logs/issue-{n}/step-{idx}-{agent}.md` for post-mortem debugging
- `StreamParser` now accumulates all text blocks without truncation and exposes them via `full_output`; `AgentResult.output` carries the full text
- Read, Glob, and Grep tool calls are now logged via `logger.debug` so `--verbose` runs produce a complete audit trail in the per-issue `.log` file

## Changes

- `lib/ocak/stream_parser.rb` — add `@full_text_blocks` accumulator, `full_output` accessor, and `logger.debug` calls for Read/Glob/Grep events
- `lib/ocak/claude_runner.rb` — use `parser.full_output` (falling back to `result_text`) for `AgentResult#output`
- `lib/ocak/pipeline_executor.rb` — add `write_step_output` to write sidecar `.md` files after each step; wrap verification output in XML tags for implementer fix prompt
- `lib/ocak/planner.rb` — wrap review output in XML tags in the fix step prompt
- `lib/ocak/templates/gitignore_additions.txt` — add `.ocak/logs/` to prevent sidecar files from being committed

## Testing

- `bundle exec rspec` — passed (130 examples, 0 failures)