### PR TITLE
fix(agent_generator): add missing require 'open3'

### DIFF
--- a/lib/ocak/agent_generator.rb
+++ b/lib/ocak/agent_generator.rb
@@ -2,6 +2,7 @@
 
 require 'erb'
 require 'fileutils'
+require 'open3'
 
 module Ocak
   class AgentGenerator


### PR DESCRIPTION
## Summary

Closes #62

- Adds explicit `require 'open3'` to `agent_generator.rb` to match the codebase convention
- Prevents a latent `NameError` that could surface under load orders where `open3` isn't already pulled in transitively

## Changes

- `lib/ocak/agent_generator.rb` — added `require 'open3'` alongside existing `require 'erb'` and `require 'fileutils'`

## Testing

- `bundle exec rspec` — passed (552 examples, 0 failures)
- `bundle exec rubocop` — passed (65 files, no offenses)