### PR TITLE
fix(planner): guard against nil/non-Array batches in parse_planner_output

### DIFF
--- a/lib/ocak/planner.rb
+++ b/lib/ocak/planner.rb
@@ -46,7 +46,10 @@ module Ocak
       json_match = output.match(/\{[\s\S]*"batches"[\s\S]*\}/)
       if json_match
         parsed = JSON.parse(json_match[0])
-        parsed['batches']
+        batches = parsed['batches']
+        return sequential_batches(issues) unless batches.is_a?(Array)
+
+        batches
       else
         logger.warn('Could not parse planner output, falling back to sequential')
         sequential_batches(issues)

--- a/spec/ocak/planner_spec.rb
+++ b/spec/ocak/planner_spec.rb
@@ -106,6 +106,24 @@ RSpec.describe Ocak::Planner do
       expect(logger).to have_received(:warn).with(/Could not parse/)
     end
 
+    it 'falls back to sequential when batches key is missing from valid JSON' do
+      output = '{"plans": [{"id": 1}]}'
+
+      result = host.parse_planner_output(output, issues, logger)
+
+      expect(result.size).to eq(1)
+      expect(result[0]['batch']).to eq(1)
+    end
+
+    it 'falls back to sequential when batches is not an array' do
+      output = '{"batches": "not an array"}'
+
+      result = host.parse_planner_output(output, issues, logger)
+
+      expect(result.size).to eq(1)
+      expect(result[0]['batch']).to eq(1)
+    end
+
     it 'falls back to sequential on malformed JSON' do
       output = '{"batches": [invalid json}'
 


### PR DESCRIPTION
## Summary

Closes #59

- `parse_planner_output` now falls back to `sequential_batches` when the planner JSON response has no `batches` key or the value is not an Array
- Prevents `NoMethodError: undefined method 'each_with_index' for nil` from crashing the entire poll loop on a hallucinated or malformed planner response

## Changes

- `lib/ocak/planner.rb` — add `is_a?(Array)` guard after extracting `batches` from parsed JSON
- `spec/ocak/planner_spec.rb` — add specs for missing `batches` key and non-Array `batches` fallback

## Testing

- `bundle exec rspec` — passed (575 examples, 0 failures)
- `bundle exec rubocop` — passed