### PR TITLE
test(cli): expand CLI routing spec coverage

### DIFF
--- a/spec/ocak/cli_spec.rb
+++ b/spec/ocak/cli_spec.rb
@@ -7,10 +7,33 @@ RSpec.describe Ocak::CLI do
   describe 'command registration' do
     let(:registry) { Ocak::CLI::Commands }
 
-    %w[init run design audit debt status clean resume hiz].each do |cmd_name|
-      it "registers the #{cmd_name} command" do
-        command_class = Ocak::Commands.const_get(cmd_name.capitalize)
-        expect(command_class).to be < Dry::CLI::Command
+    expected_commands = {
+      'init' => Ocak::Commands::Init,
+      'run' => Ocak::Commands::Run,
+      'design' => Ocak::Commands::Design,
+      'audit' => Ocak::Commands::Audit,
+      'debt' => Ocak::Commands::Debt,
+      'status' => Ocak::Commands::Status,
+      'clean' => Ocak::Commands::Clean,
+      'resume' => Ocak::Commands::Resume,
+      'hiz' => Ocak::Commands::Hiz
+    }.freeze
+
+    it 'registers all 9 commands' do
+      expected_commands.each_key do |name|
+        result = registry.get([name])
+        expect(result).to be_found, "expected '#{name}' to be registered"
+      end
+    end
+
+    expected_commands.each do |name, klass|
+      it "maps '#{name}' to #{klass}" do
+        result = registry.get([name])
+        expect(result.command).to eq(klass)
+      end
+
+      it "has a non-empty description for '#{name}'" do
+        expect(klass.description).to be_a(String).and(satisfy('be non-empty') { |s| !s.strip.empty? })
       end
     end
   end


### PR DESCRIPTION
## Summary

Closes #78

- Expanded `spec/ocak/cli_spec.rb` from 17 lines to full coverage of the CLI registry
- Verifies all 9 commands are registered (`init`, `run`, `design`, `audit`, `debt`, `status`, `clean`, `resume`, `hiz`)
- Verifies each command maps to the correct `Ocak::Commands::*` class
- Verifies command descriptions are present and non-empty

## Changes

- `spec/ocak/cli_spec.rb` — added 19 examples covering command registration, class mapping, and descriptions

## Testing

- `bundle exec rspec` — 597 examples, 0 failures
- `bundle exec rubocop -A` — no offenses detected