### PR TITLE
fix(issue_fetcher): remove dead code branch in authorized_issue?

### DIFF
--- a/lib/ocak/issue_fetcher.rb
+++ b/lib/ocak/issue_fetcher.rb
@@ -155,8 +155,6 @@ module Ocak
       authors = allowed_authors
       author_login = issue.dig('author', 'login')
 
-      return true if authors.empty? && @config.allowed_authors.any?
-
       if authors.any? && authors.include?(author_login)
         check_comment_requirement(issue)
       elsif authors.empty?


### PR DESCRIPTION
## Summary

Closes #72

- Removes unreachable `return true if authors.empty? && @config.allowed_authors.any?` line from `IssueFetcher#authorized_issue?`
- The condition could never be true since `authors` is assigned from `allowed_authors` which returns `@config.allowed_authors` — the same array cannot be both empty and non-empty

## Changes

- `lib/ocak/issue_fetcher.rb` — removed 2 lines of dead code

## Testing

- `bundle exec rspec` — 641 examples, 0 failures
- `bundle exec rubocop -A` — 68 files inspected, no offenses detected