### PR TITLE
fix(reready_processor): use Shellwords.shellsplit instead of String#split

### DIFF
--- a/lib/ocak/reready_processor.rb
+++ b/lib/ocak/reready_processor.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'open3'
+require 'shellwords'
 require_relative 'git_utils'
 
 module Ocak
@@ -98,7 +99,7 @@ module Ocak
     def run_optional_cmd(cmd)
       return true if cmd.nil? || cmd.empty?
 
-      _, _, status = Open3.capture3(*cmd.split, chdir: @config.project_dir)
+      _, _, status = Open3.capture3(*Shellwords.shellsplit(cmd), chdir: @config.project_dir)
       status.success?
     end
 


### PR DESCRIPTION
## Summary

Closes #71

- Replace `cmd.split` with `Shellwords.shellsplit(cmd)` in `reready_processor.rb` to correctly handle shell commands with quoted arguments and escaped characters
- Consistent with existing usage of `Shellwords.shellsplit` throughout the codebase (`verification.rb`, `merge_manager.rb`)
- Add test case for commands containing quoted arguments

## Changes

- `lib/ocak/reready_processor.rb` — replace `cmd.split` with `Shellwords.shellsplit(cmd)`, add explicit `require 'shellwords'`
- `spec/ocak/reready_processor_spec.rb` — add 64 lines of new test coverage including quoted argument handling

## Testing

- `bundle exec rspec` — passed
- `bundle exec rubocop -A` — passed