### PR TITLE
fix(security): wrap verification output in XML tags in Hiz command

### DIFF
--- a/lib/ocak/commands/hiz.rb
+++ b/lib/ocak/commands/hiz.rb
@@ -178,8 +178,9 @@ module Ocak
           post_step_comment(issue_number,
                             "\u{26A0}\u{FE0F} **Final verification failed** \u2014 attempting auto-fix...",
                             state: state)
-          claude.run_agent('implementer',
-                           "Fix these test/lint failures:\n\n#{result[:output]}",
+          fix_prompt = "Fix these test/lint failures:\n\n" \
+                       "<verification_output>\n#{result[:output]}\n</verification_output>"
+          claude.run_agent('implementer', fix_prompt,
                            chdir: chdir, model: STEP_MODELS['implementer'])
           result = run_final_checks(logger, chdir: chdir)
         end


### PR DESCRIPTION
## Summary

Closes #70

- Wraps verification output in `<verification_output>` XML tags before passing to the implementer agent in `Hiz#run_final_verification_step`
- Fixes prompt injection risk where test/lint output could contain text interpreted as LLM instructions
- Aligns `hiz.rb` with the existing pattern in `pipeline_executor.rb:232-233`

## Changes

- `lib/ocak/commands/hiz.rb` — build `fix_prompt` with `<verification_output>` XML delimiters around the result output
- `spec/ocak/commands/hiz_spec.rb` — add test verifying XML wrapping is present in the prompt passed to the implementer agent

## Testing

- `bundle exec rspec` — passed (642 examples, 0 failures)
- `bundle exec rubocop -A` — passed (68 files, no offenses)