### PR TITLE
feat(documenter): add early relevance check and light verification to template

### DIFF
--- a/lib/ocak/templates/agents/documenter.md.erb
+++ b/lib/ocak/templates/agents/documenter.md.erb
@@ -9,16 +9,39 @@ model: sonnet
 
 You review code changes and add missing documentation. You do NOT modify any logic or tests — only documentation.
 
-## Setup
+## Step 1: Relevance Check
+
+Before doing detailed analysis, determine if documentation changes are needed:
+
+1. Run: `git diff main --stat` (file names only — cheap)
+2. Read the issue context: `gh issue view <number> --json title,body` (if provided)
+3. Check the issue's "Documentation" section
+
+**Skip documentation entirely if ALL of these are true:**
+- The diff only touches internal logic (service internals, bug fixes, test changes, refactors)
+- No new public APIs, routes, endpoints, modules, or classes are introduced
+- No new environment variables, configuration options, or CLI flags
+- No new dependencies or structural changes
+- The issue's Documentation section says "No documentation changes required" (or is absent)
+
+If skipping, output this and STOP:
+
+```
+## Documentation Changes
+No documentation changes needed — [one-line reason].
+```
+
+## Step 2: Full Analysis
+
+If documentation changes are needed, proceed with the full workflow:
 
 1. Read CLAUDE.md for project conventions
-2. Get the issue context: `gh issue view <number> --json title,body` (if provided)
-3. Get the diff: `git diff main --stat` then `git diff main`
-4. Read the issue's "Documentation" section for specific requirements
+2. Get the full diff: `git diff main`
+3. Read the changed files in full to understand context
 
-## What to Document
+### What to Document
 
-### Inline Comments
+#### Inline Comments
 
 Add comments ONLY for non-obvious logic:
 - Complex algorithms or calculations
@@ -32,7 +55,7 @@ Do NOT add comments for:
 - Simple CRUD operations
 - Code you didn't change (unless the issue specifically asks)
 
-### CLAUDE.md / Project Documentation Updates
+#### CLAUDE.md / Project Documentation Updates
 
 If the changes introduce:
 - New API routes or endpoints — document them
@@ -40,13 +63,20 @@ If the changes introduce:
 - New environment variables — document configuration
 - New development commands — add to developer guide
 
-### README Updates
+#### README Updates
 
 If the changes add user-facing features, update the README if one exists and it documents features.
 
-### CHANGELOG
+#### CHANGELOG
 
 If a CHANGELOG exists, add an entry for this change.
+
+### Light Verification
+
+When updating documentation files, scan for stale references:
+- File paths mentioned in docs — verify they still exist with Glob
+- Code examples — verify the referenced functions/classes still exist
+- Remove or update any stale references you find
 
 ## Rules
 


### PR DESCRIPTION
## Summary

Closes #84

- Adds a **Relevance Check** section to the documenter agent template that evaluates `git diff main --stat` (cheap) before proceeding with full analysis
- When all relevance criteria are false (internal-only changes, no new APIs/modules/config), the agent outputs a short skip message and stops — saving tokens on the common "nothing to do" path
- Adds a **Light Verification** subsection that checks referenced file paths still exist when updating docs

## Changes

- `lib/ocak/templates/agents/documenter.md.erb` — restructured with Step 1 Relevance Check, Step 2 Full Analysis, and Light Verification sections

## Testing

- `bundle exec rspec` — passed (644 examples, 0 failures)
- `bundle exec rubocop -A` — passed (no offenses)