### PR TITLE
feat(pipeline): add --fast flag for lean pipeline execution

### DIFF
--- a/lib/ocak/commands/run.rb
+++ b/lib/ocak/commands/run.rb
@@ -24,6 +24,8 @@ module Ocak
                              desc: 'Create PRs without auto-merge; wait for human review'
       option :audit, type: :boolean, default: false,
                      desc: 'Run auditor as post-pipeline gate; create PR with findings if issues found'
+      option :fast, type: :boolean, default: false,
+                    desc: 'Lean pipeline — skip security, document, audit steps'
       option :verbose, type: :boolean, default: false, desc: 'Increase log detail'
       option :quiet, type: :boolean, default: false, desc: 'Suppress non-error output'
 
@@ -45,6 +47,7 @@ module Ocak
             single: issue&.to_i,
             dry_run: options[:dry_run],
             once: options[:once],
+            fast: options[:fast],
             log_level: log_level
           }
         )

--- a/lib/ocak/config.rb
+++ b/lib/ocak/config.rb
@@ -103,9 +103,10 @@ module Ocak
         { agent: 'reviewer', role: 'review' },
         { agent: 'implementer', role: 'fix', condition: 'has_findings' },
         { agent: 'reviewer', role: 'verify', condition: 'had_fixes' },
-        { agent: 'security-reviewer', role: 'security' },
+        { agent: 'security-reviewer', role: 'security', complexity: 'full' },
         { agent: 'implementer', role: 'fix', condition: 'has_findings', complexity: 'full' },
         { agent: 'documenter', role: 'document', complexity: 'full' },
+        { agent: 'auditor', role: 'audit', complexity: 'full' },
         { agent: 'merger', role: 'merge' }
       ]
     end

--- a/lib/ocak/pipeline_runner.rb
+++ b/lib/ocak/pipeline_runner.rb
@@ -73,7 +73,8 @@ module Ocak
       end
 
       issues.transition(issue_number, from: @config.label_ready, to: @config.label_in_progress)
-      result = run_pipeline(issue_number, logger: logger, claude: claude)
+      complexity = @options[:fast] ? 'simple' : 'full'
+      result = run_pipeline(issue_number, logger: logger, claude: claude, complexity: complexity)
 
       if result[:interrupted]
         handle_interrupted_issue(issue_number, nil, result[:phase], logger: logger, issues: issues)
@@ -178,8 +179,9 @@ module Ocak
       worktree = worktrees.create(issue_number, setup_command: @config.setup_command)
       logger.info("Created worktree at #{worktree.path} (branch: #{worktree.branch})")
 
+      complexity = @options[:fast] ? 'simple' : issue.fetch('complexity', 'full')
       result = run_pipeline(issue_number, logger: logger, claude: claude, chdir: worktree.path,
-                                          complexity: issue.fetch('complexity', 'full'))
+                                          complexity: complexity)
 
       build_issue_result(result, issue_number: issue_number, worktree: worktree, issues: issues,
                                  logger: logger)

--- a/lib/ocak/templates/ocak.yml.erb
+++ b/lib/ocak/templates/ocak.yml.erb
@@ -66,6 +66,7 @@ steps:
     condition: had_fixes
   - agent: security_reviewer
     role: security
+    complexity: full          # skipped for simple issues and --fast mode
   - agent: implementer
     role: fix
     condition: has_findings

--- a/spec/ocak/commands/run_spec.rb
+++ b/spec/ocak/commands/run_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Ocak::Commands::Run do
 
     expect(Ocak::PipelineRunner).to have_received(:new).with(
       config: config,
-      options: { watch: true, single: 42, dry_run: true, once: true, log_level: :normal }
+      options: { watch: true, single: 42, dry_run: true, once: true, fast: nil, log_level: :normal }
     )
   end
 
@@ -117,6 +117,24 @@ RSpec.describe Ocak::Commands::Run do
     expect(Ocak::PipelineRunner).to have_received(:new).with(
       config: config,
       options: hash_including(log_level: :quiet)
+    )
+  end
+
+  it 'passes fast flag in options to PipelineRunner' do
+    command.call(fast: true)
+
+    expect(Ocak::PipelineRunner).to have_received(:new).with(
+      config: config,
+      options: hash_including(fast: true)
+    )
+  end
+
+  it 'defaults fast flag to nil when not specified' do
+    command.call
+
+    expect(Ocak::PipelineRunner).to have_received(:new).with(
+      config: config,
+      options: hash_including(fast: nil)
     )
   end
 

--- a/spec/ocak/config_spec.rb
+++ b/spec/ocak/config_spec.rb
@@ -205,13 +205,20 @@ RSpec.describe Ocak::Config do
   describe '#steps' do
     it 'returns default steps when none configured' do
       config = described_class.new({}, dir)
-      expect(config.steps.size).to eq(8)
+      expect(config.steps.size).to eq(9)
       expect(config.steps.first).to include(agent: 'implementer', role: 'implement')
     end
 
-    it 'does not include audit step in default steps' do
+    it 'includes audit step in default steps with full complexity' do
       config = described_class.new({}, dir)
-      expect(config.steps.none? { |s| s[:role] == 'audit' }).to be true
+      audit_step = config.steps.find { |s| s[:role] == 'audit' }
+      expect(audit_step).to include(agent: 'auditor', role: 'audit', complexity: 'full')
+    end
+
+    it 'includes security step in default steps with full complexity' do
+      config = described_class.new({}, dir)
+      security_step = config.steps.find { |s| s[:role] == 'security' }
+      expect(security_step).to include(agent: 'security-reviewer', role: 'security', complexity: 'full')
     end
 
     it 'returns configured steps' do

--- a/spec/ocak/pipeline_executor_spec.rb
+++ b/spec/ocak/pipeline_executor_spec.rb
@@ -195,6 +195,34 @@ RSpec.describe Ocak::PipelineExecutor do
 
       expect(claude).to have_received(:run_agent).with('documenter', anything, chdir: anything)
     end
+
+    it 'skips security step with complexity full for simple issues' do
+      steps_with_security = [
+        { 'agent' => 'implementer', 'role' => 'implement' },
+        { 'agent' => 'reviewer', 'role' => 'review' },
+        { 'agent' => 'security-reviewer', 'role' => 'security', 'complexity' => 'full' },
+        { 'agent' => 'merger', 'role' => 'merge' }
+      ]
+      allow(config).to receive(:steps).and_return(steps_with_security)
+
+      executor.run_pipeline(10, logger: logger, claude: claude, complexity: 'simple')
+
+      expect(claude).not_to have_received(:run_agent).with('security-reviewer', anything, chdir: anything)
+    end
+
+    it 'runs security step with complexity full for full issues' do
+      steps_with_security = [
+        { 'agent' => 'implementer', 'role' => 'implement' },
+        { 'agent' => 'reviewer', 'role' => 'review' },
+        { 'agent' => 'security-reviewer', 'role' => 'security', 'complexity' => 'full' },
+        { 'agent' => 'merger', 'role' => 'merge' }
+      ]
+      allow(config).to receive(:steps).and_return(steps_with_security)
+
+      executor.run_pipeline(10, logger: logger, claude: claude, complexity: 'full')
+
+      expect(claude).to have_received(:run_agent).with('security-reviewer', anything, chdir: anything)
+    end
   end
 
   describe 'manual review mode' do


### PR DESCRIPTION
## Summary

Closes #83

- Adds `--fast` CLI flag to `ocak run` that forces `simple` complexity for all issues, skipping security, document, and audit steps
- Marks security step with `complexity: 'full'` in `default_steps` and `ocak.yml.erb` template so it's skipped in fast mode
- Adds auditor step to `default_steps` in `config.rb` to match the `ocak.yml.erb` template

## Changes

- `lib/ocak/commands/run.rb` — add `--fast` boolean option, pass it through to PipelineRunner
- `lib/ocak/pipeline_runner.rb` — use `fast` flag to override complexity to `'simple'` in both single-issue and batch modes
- `lib/ocak/config.rb` — add `complexity: 'full'` to security step, add auditor step to `default_steps`
- `lib/ocak/templates/ocak.yml.erb` — add `complexity: full` comment to security step
- `spec/ocak/commands/run_spec.rb` — test `--fast` flag passes through to PipelineRunner
- `spec/ocak/pipeline_executor_spec.rb` — test security step with `complexity: 'full'` is skipped for simple issues

## Testing

- `bundle exec rspec` — passed (649 examples, 0 failures)
- `bundle exec rubocop -A` — passed (68 files, no offenses)