### PR TITLE
fix(process_runner): rescue Errno::EPERM in kill_process

### DIFF
--- a/lib/ocak/process_runner.rb
+++ b/lib/ocak/process_runner.rb
@@ -56,7 +56,7 @@ module Ocak
       Process.kill('TERM', pid)
       sleep 2
       Process.kill('KILL', pid)
-    rescue Errno::ESRCH => e
+    rescue Errno::ESRCH, Errno::EPERM => e
       warn("Process already exited during kill: #{e.message}")
       nil
     end


### PR DESCRIPTION
## Summary

Closes #100

- `kill_process` only rescued `Errno::ESRCH` but `Process.kill` can also raise `Errno::EPERM` when the caller lacks permission to signal a process
- An unrescued `Errno::EPERM` would propagate out of `read_streams`, crashing the streaming loop
- Aligns with `ProcessRegistry#kill_all` which already rescues both errors

## Changes

- `lib/ocak/process_runner.rb` — change `rescue Errno::ESRCH` to `rescue Errno::ESRCH, Errno::EPERM`
- `spec/ocak/process_runner_spec.rb` — add test that stubs `Process.kill` to raise `Errno::EPERM` and asserts `run` completes without raising

## Testing

- `bundle exec rspec spec/ocak/process_runner_spec.rb` — passed (9 examples, 0 failures)
- `bundle exec rubocop lib/ocak/process_runner.rb spec/ocak/process_runner_spec.rb` — passed (no offenses)