### PR TITLE
chore(deps): remove redundant logger gem, tighten dev dependency versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,6 @@ gemspec
 
 group :development, :test do
   gem 'rake', '~> 13.0'
-  gem 'rspec', '~> 3.0'
-  gem 'rubocop', '~> 1.0', require: false
+  gem 'rspec', '~> 3.13'
+  gem 'rubocop', '~> 1.85', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,6 @@ PATH
   specs:
     ocak (0.3.0)
       dry-cli (~> 1.0)
-      logger (~> 1.6)
 
 GEM
   remote: https://rubygems.org/
@@ -20,7 +19,6 @@ GEM
       bigdecimal (>= 3.1, < 5)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
-    logger (1.7.0)
     mcp (0.7.1)
       json-schema (>= 4.1)
     parallel (1.27.0)
@@ -73,8 +71,8 @@ PLATFORMS
 DEPENDENCIES
   ocak!
   rake (~> 13.0)
-  rspec (~> 3.0)
-  rubocop (~> 1.0)
+  rspec (~> 3.13)
+  rubocop (~> 1.85)
 
 CHECKSUMS
   addressable (2.8.8) sha256=7c13b8f9536cf6364c03b9d417c19986019e28f7c00ac8132da4eb0fe393b057
@@ -86,7 +84,6 @@ CHECKSUMS
   json-schema (6.1.0) sha256=6bf70a2cfb6dfd5a06da28093fa8190f324c88eabd36a7f47097f227321dc702
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
-  logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   mcp (0.7.1) sha256=fa967895d6952bad0d981ea907731d8528d2c246d2079d56a9c8bae83d14f1c7
   ocak (0.3.0)
   parallel (1.27.0) sha256=4ac151e1806b755fb4e2dc2332cbf0e54f2e24ba821ff2d3dcf86bf6dc4ae130

--- a/ocak.gemspec
+++ b/ocak.gemspec
@@ -24,5 +24,4 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'dry-cli', '~> 1.0'
-  spec.add_dependency 'logger', '~> 1.6'
 end


### PR DESCRIPTION
## Summary

Closes #113

- Remove `spec.add_dependency 'logger', '~> 1.6'` from `ocak.gemspec` — unnecessary for Ruby >= 3.4 where logger is a default gem
- Tighten `rubocop` version constraint from `~> 1.0` to `~> 1.85` to prevent unexpected cop additions on `bundle update`
- Tighten `rspec` version constraint from `~> 3.0` to `~> 3.13` to better express intent

## Changes

- `ocak.gemspec` — removed redundant `logger` runtime dependency
- `Gemfile` — tightened `rubocop` and `rspec` version constraints
- `Gemfile.lock` — updated lockfile after `bundle install`

## Testing

- `bundle exec rspec` — passed (663 examples, 0 failures)
- `bundle exec rubocop -A` — passed (70 files, no offenses)