### PR TITLE
fix(pipeline_state): add error handling to PipelineState#save

### DIFF
--- a/lib/ocak/pipeline_state.rb
+++ b/lib/ocak/pipeline_state.rb
@@ -5,8 +5,9 @@ require 'fileutils'
 
 module Ocak
   class PipelineState
-    def initialize(log_dir:)
+    def initialize(log_dir:, logger: nil)
       @log_dir = log_dir
+      @logger = logger
     end
 
     def save(issue_number, completed_steps:, worktree_path: nil, branch: nil)
@@ -18,6 +19,10 @@ module Ocak
                                                                   branch: branch,
                                                                   updated_at: Time.now.iso8601
                                                                 }))
+    rescue StandardError => e
+      @logger&.warn("Pipeline state save failed for issue ##{issue_number}: #{e.message}") ||
+        warn("Pipeline state save failed for issue ##{issue_number}: #{e.message}")
+      nil
     end
 
     def load(issue_number)


### PR DESCRIPTION
## Summary

Closes #108

- Wraps `FileUtils.mkdir_p` and `File.write` in a `rescue StandardError` block in `PipelineState#save`
- Logs a warning on failure instead of crashing the pipeline
- Returns `nil` on failure, consistent with `save_report` in `pipeline_executor.rb`

## Changes

- `lib/ocak/pipeline_state.rb` — add rescue block to `save`, warn on failure, return nil
- `spec/ocak/pipeline_state_spec.rb` — add tests covering `Errno::ENOSPC` and other write failures

## Testing

- `bundle exec rspec` — passed (667 examples, 0 failures)
- `bundle exec rubocop -A` — passed (no offenses)