### PR TITLE
fix(merge_manager): wrap conflicting filenames in XML delimiters

### DIFF
--- a/lib/ocak/merge_manager.rb
+++ b/lib/ocak/merge_manager.rb
@@ -149,7 +149,7 @@ module Ocak
 
       result = @claude.run_agent(
         'implementer',
-        "Resolve these merge conflicts. Conflicting files:\n#{conflicting.join("\n")}\n\n" \
+        "Resolve these merge conflicts.\n\n<conflicting_files>\n#{conflicting.join("\n")}\n</conflicting_files>\n\n" \
         'Open each file, find conflict markers (<<<<<<< ======= >>>>>>>), and resolve them. ' \
         'Then run `git add` on each resolved file.',
         chdir: worktree.path


### PR DESCRIPTION
## Summary

Closes #106

- Wraps conflicting filenames from `git diff --name-only --diff-filter=U` in `<conflicting_files>` XML delimiters before embedding in the implementer agent prompt
- Prevents crafted filenames from a malicious upstream branch being interpreted as prompt instructions
- No behavioral change — purely a prompt injection protection improvement per CLAUDE.md conventions

## Changes

- `lib/ocak/merge_manager.rb` — wrap `conflicting.join("\n")` in `<conflicting_files>` tags in the conflict resolution prompt

## Testing

- `bundle exec rspec` — passed (673 examples, 0 failures)
- `bundle exec rubocop -A` — passed (no offenses)