### PR TITLE
fix(merge_manager): check git commit --no-edit return status in resolve_conflicts_via_agent

### DIFF
--- a/lib/ocak/merge_manager.rb
+++ b/lib/ocak/merge_manager.rb
@@ -160,7 +160,11 @@ module Ocak
         # Check if all conflicts resolved
         remaining, = git('diff', '--name-only', '--diff-filter=U', chdir: worktree.path)
         if remaining.strip.empty?
-          git('commit', '--no-edit', chdir: worktree.path)
+          _, commit_stderr, commit_status = git('commit', '--no-edit', chdir: worktree.path)
+          unless commit_status.success?
+            @logger.error("Commit after conflict resolution failed: #{commit_stderr}")
+            return false
+          end
           @logger.info('Merge conflicts resolved by agent')
           return true
         end


### PR DESCRIPTION
## Summary

Closes #98

- Checked the return status of `git commit --no-edit` after agent-resolved merge conflicts in `resolve_conflicts_via_agent`
- On commit failure, log an error with stderr output and return `false` instead of silently returning `true`
- Added tests for both the failure path (non-zero commit status returns `false`) and the success path

## Changes

- `lib/ocak/merge_manager.rb` — capture and check commit return status; log error and return `false` on failure
- `spec/ocak/merge_manager_spec.rb` — added test cases for commit failure and commit success in `resolve_conflicts_via_agent`

## Testing

- `bundle exec rspec` — passed (677 examples, 0 failures)
- `bundle exec rubocop -A` — passed (70 files, no offenses)