### PR TITLE
refactor(git_utils): extract checkout_main and remove dead create_pr key

### DIFF
--- a/lib/ocak/commands/hiz.rb
+++ b/lib/ocak/commands/hiz.rb
@@ -252,8 +252,7 @@ module Ocak
         issues.comment(issue_number,
                        "Hiz (fast mode) failed at phase: #{phase}\n\n```\n#{output.to_s[0..1000]}\n```")
         warn "Issue ##{issue_number} failed at phase: #{phase}"
-        _, stderr, status = Open3.capture3('git', 'checkout', 'main', chdir: @config.project_dir)
-        logger.warn("Cleanup checkout to main failed: #{stderr}") unless status.success?
+        GitUtils.checkout_main(chdir: @config.project_dir, logger: logger)
       end
 
       def build_logger(issue_number)

--- a/lib/ocak/git_utils.rb
+++ b/lib/ocak/git_utils.rb
@@ -38,5 +38,14 @@ module Ocak
 
       true
     end
+
+    # Checks out the main branch. Intended for cleanup/ensure blocks.
+    # Rescues all errors so it never crashes the caller.
+    def self.checkout_main(chdir:, logger: nil)
+      _, stderr, status = Open3.capture3('git', 'checkout', 'main', chdir: chdir)
+      logger&.warn("Cleanup checkout to main failed: #{stderr}") unless status.success?
+    rescue StandardError => e
+      logger&.warn("Cleanup checkout to main error: #{e.message}")
+    end
   end
 end

--- a/lib/ocak/planner.rb
+++ b/lib/ocak/planner.rb
@@ -11,8 +11,7 @@ module Ocak
       'verify' => 'Review the changes for GitHub issue #%<issue>s. Run: git diff main',
       'security' => 'Security review changes for GitHub issue #%<issue>s. Run: git diff main',
       'document' => 'Add documentation for changes in GitHub issue #%<issue>s',
-      'merge' => 'Create a PR, merge it, and close issue #%<issue>s',
-      'create_pr' => 'Create a PR, merge it, and close issue #%<issue>s'
+      'merge' => 'Create a PR, merge it, and close issue #%<issue>s'
     }.freeze
 
     def build_step_prompt(role, issue_number, review_output)

--- a/lib/ocak/reready_processor.rb
+++ b/lib/ocak/reready_processor.rb
@@ -133,8 +133,7 @@ module Ocak
     end
 
     def cleanup
-      _, stderr, status = Open3.capture3('git', 'checkout', 'main', chdir: @config.project_dir)
-      @logger.warn("Cleanup checkout to main failed: #{stderr}") unless status.success?
+      GitUtils.checkout_main(chdir: @config.project_dir, logger: @logger)
     end
 
     def build_feedback_prompt(feedback)


### PR DESCRIPTION
## Summary

Closes #111

- Add `GitUtils.checkout_main(chdir:, logger: nil)` class method to centralize the repeated inline checkout-to-main logic
- Replace duplicate inline checkout logic in `hiz.rb` and `reready_processor.rb` with the shared method
- Remove dead `'create_pr'` key from `STEP_PROMPTS` in `planner.rb`

## Changes

- `lib/ocak/git_utils.rb` — add `checkout_main` class method with `rescue StandardError => e` guard since it runs in `ensure` blocks
- `lib/ocak/commands/hiz.rb` — replace inline checkout logic with `GitUtils.checkout_main`
- `lib/ocak/reready_processor.rb` — replace inline checkout logic with `GitUtils.checkout_main`
- `lib/ocak/planner.rb` — remove unused `'create_pr'` entry from `STEP_PROMPTS`
- `spec/ocak/git_utils_spec.rb` — add tests for `GitUtils.checkout_main`

## Testing

- `bundle exec rspec` — passed (684 examples, 0 failures)
- `bundle exec rubocop` — passed (70 files, no offenses)