### PR TITLE
refactor(process_runner,agent_generator,init): minor pattern cleanups

### DIFF
--- a/lib/ocak/agent_generator.rb
+++ b/lib/ocak/agent_generator.rb
@@ -109,7 +109,7 @@ module Ocak
         agent_path = File.join(output_dir, "#{output_name}.md")
         current_content = File.read(agent_path)
 
-        prompt = build_enhancement_prompt(agent, current_content, context)
+        prompt = build_enhancement_prompt(current_content, context)
         result = run_claude_prompt(prompt)
 
         if result && !result.strip.empty? && result.include?('---')
@@ -131,7 +131,7 @@ module Ocak
       parts.join("\n\n")
     end
 
-    def build_enhancement_prompt(_agent, template_content, context)
+    def build_enhancement_prompt(template_content, context)
       <<~PROMPT
         You are customizing a Claude Code agent for a specific project.
 

--- a/lib/ocak/commands/init.rb
+++ b/lib/ocak/commands/init.rb
@@ -211,11 +211,7 @@ module Ocak
       end
 
       def init_logger
-        @init_logger ||= Object.new.tap do |l|
-          def l.info(msg)
-            puts "  #{msg}"
-          end
-        end
+        @init_logger ||= Struct.new(:_) { def info(msg) = puts("  #{msg}") }.new
       end
     end
   end

--- a/lib/ocak/process_runner.rb
+++ b/lib/ocak/process_runner.rb
@@ -5,6 +5,8 @@ require 'open3'
 module Ocak
   # Runs a subprocess with streaming line output and timeout support.
   module ProcessRunner
+    KILL_GRACE_PERIOD = 2
+
     FailedStatus = Struct.new(:success?) do
       def self.instance = new(false)
     end
@@ -54,7 +56,7 @@ module Ocak
 
     def kill_process(pid)
       Process.kill('TERM', pid)
-      sleep 2
+      sleep KILL_GRACE_PERIOD
       Process.kill('KILL', pid)
     rescue Errno::ESRCH, Errno::EPERM => e
       warn("Process already exited during kill: #{e.message}")


### PR DESCRIPTION
## Summary

Closes #114

- Extract `KILL_GRACE_PERIOD = 2` constant in `ProcessRunner` so the hardcoded `sleep 2` in `kill_process` references a named constant, aligning with the pattern used by `ProcessRegistry::KILL_WAIT`
- Remove unused `_agent` parameter from `AgentGenerator#build_enhancement_prompt` and simplify the call site, since the enhancement prompt is identical for every agent
- Replace the unconventional `Object.new.tap` singleton method pattern in `Init#init_logger` with a simple `Struct.new` approach that is safer with `verify_partial_doubles`

## Changes

- `lib/ocak/process_runner.rb` — add `KILL_GRACE_PERIOD = 2` constant, reference it in `kill_process`
- `lib/ocak/agent_generator.rb` — remove `_agent` param from `build_enhancement_prompt` and its call site
- `lib/ocak/commands/init.rb` — replace `Object.new.tap` pattern with `Struct.new` in `init_logger`

## Testing

- `bundle exec rspec` — passed
- `bundle exec rubocop -A` — passed