### PR TITLE
fix(verification): handle Shellwords.shellsplit ArgumentError for malformed commands

### DIFF
--- a/lib/ocak/reready_processor.rb
+++ b/lib/ocak/reready_processor.rb
@@ -101,6 +101,9 @@ module Ocak
 
       _, _, status = Open3.capture3(*Shellwords.shellsplit(cmd), chdir: @config.project_dir)
       status.success?
+    rescue ArgumentError => e
+      @logger&.warn("Invalid shell command in config: #{cmd.inspect} (#{e.message})")
+      false
     end
 
     def handle_result(pr_number, success)


### PR DESCRIPTION
## Summary

Closes #107

- Rescues `ArgumentError` from `Shellwords.shellsplit` in three locations: `reready_processor.rb#run_optional_cmd`, `verification.rb#check_tests`, and `verification.rb#run_scoped_lint`
- Logs a clear config error message instead of crashing with a confusing exception when `lint_command` or `test_command` in `ocak.yml` contains unmatched quotes
- Returns a failure result (`false` or `{ success: false }`) so the pipeline fails gracefully

## Changes

- `lib/ocak/reready_processor.rb` — added `ArgumentError` rescue in `run_optional_cmd`
- `lib/ocak/verification.rb` — added `ArgumentError` rescue in `check_tests` and `run_scoped_lint`
- `spec/ocak/reready_processor_spec.rb` — tests for malformed command handling in `run_optional_cmd`
- `spec/ocak/verification_spec.rb` — tests for malformed command handling in `check_tests` and `run_scoped_lint`

## Testing

- `bundle exec rspec` — passed
- `bundle exec rubocop -A` — passed