### PR TITLE
test(specs): add coverage for untested rescue/error paths

### DIFF
--- a/spec/ocak/commands/hiz_spec.rb
+++ b/spec/ocak/commands/hiz_spec.rb
@@ -500,6 +500,16 @@ RSpec.describe Ocak::Commands::Hiz do
     end
   end
 
+  describe 'create_branch failure' do
+    it 'raises RuntimeError when git checkout -b fails' do
+      allow(Open3).to receive(:capture3)
+        .with('git', 'checkout', '-b', anything, chdir: '/project')
+        .and_return(['', 'fatal: cannot create branch', failure_status])
+
+      expect { command.call(issue: '42') }.to raise_error(RuntimeError, /Failed to create branch/)
+    end
+  end
+
   it 'exits with error on ConfigNotFound' do
     allow(Ocak::Config).to receive(:load).and_raise(Ocak::Config::ConfigNotFound, 'not found')
 

--- a/spec/ocak/git_utils_spec.rb
+++ b/spec/ocak/git_utils_spec.rb
@@ -168,12 +168,12 @@ RSpec.describe Ocak::GitUtils do
           .and_return(['', 'error', failure_status])
       end
 
-      it 'does not raise when logger is nil' do
-        expect { described_class.commit_changes(chdir: chdir, message: message) }.not_to raise_error
-      end
+      it 'does not raise when logger is nil and still attempts git commands' do
+        result = described_class.commit_changes(chdir: chdir, message: message)
 
-      it 'returns false on failure' do
-        expect(described_class.commit_changes(chdir: chdir, message: message)).to be false
+        expect(result).to be false
+        expect(Open3).to have_received(:capture3)
+          .with('git', 'add', '-A', chdir: chdir)
       end
     end
   end

--- a/spec/ocak/logger_spec.rb
+++ b/spec/ocak/logger_spec.rb
@@ -44,6 +44,39 @@ RSpec.describe Ocak::PipelineLogger do
       expect { logger.info('plain') }.to output(/INFO: plain/).to_stderr_from_any_process
     end
   end
+
+  describe 'log level suppression' do
+    it 'suppresses info messages in quiet mode' do
+      logger = described_class.new(color: false, log_level: :quiet)
+      expect { logger.info('hidden') }.not_to output.to_stderr_from_any_process
+    end
+
+    it 'still outputs warn messages in quiet mode' do
+      logger = described_class.new(color: false, log_level: :quiet)
+      expect { logger.warn('visible') }.to output(/WARN: visible/).to_stderr_from_any_process
+    end
+
+    it 'suppresses debug messages in normal mode' do
+      logger = described_class.new(color: false, log_level: :normal)
+      expect { logger.debug('hidden') }.not_to output.to_stderr_from_any_process
+    end
+
+    it 'outputs debug messages in verbose mode' do
+      logger = described_class.new(color: false, log_level: :verbose)
+      expect { logger.debug('visible') }.to output(/DEBUG: visible/).to_stderr_from_any_process
+    end
+
+    it 'writes debug to file logger even in normal mode' do
+      dir = Dir.mktmpdir
+      logger = described_class.new(log_dir: dir, color: false, log_level: :normal)
+      logger.debug('file only')
+
+      content = File.read(logger.log_file_path)
+      expect(content).to include('file only')
+    ensure
+      FileUtils.remove_entry(dir)
+    end
+  end
 end
 
 RSpec.describe Ocak::WatchFormatter do

--- a/spec/ocak/run_report_spec.rb
+++ b/spec/ocak/run_report_spec.rb
@@ -140,6 +140,14 @@ RSpec.describe Ocak::RunReport do
       expect(hash).to have_key(:total_cost_usd)
       expect(hash).to have_key(:steps)
     end
+
+    it 'returns nil total_duration_s when finish has not been called' do
+      hash = report.to_h(42)
+
+      expect(hash[:finished_at]).to be_nil
+      expect(hash[:total_duration_s]).to be_nil
+      expect(hash[:started_at]).not_to be_nil
+    end
   end
 
   describe '.load_all' do

--- a/spec/ocak/stack_detector_spec.rb
+++ b/spec/ocak/stack_detector_spec.rb
@@ -292,6 +292,19 @@ RSpec.describe Ocak::StackDetector do
     end
   end
 
+  context 'with malformed package.json' do
+    before do
+      write_file('package.json', 'not valid json{{{')
+      write_file('tsconfig.json', '{}')
+    end
+
+    it 'detects language but returns false for package checks' do
+      expect { result }.to output(/Failed to parse package.json/).to_stderr
+      expect(result.language).to eq('typescript')
+      expect(result.framework).to be_nil
+    end
+  end
+
   context 'with an empty directory' do
     it 'returns unknown language' do
       expect(result.language).to eq('unknown')


### PR DESCRIPTION
## Summary

Closes #112

- Adds tests for 15 rescue/error paths that had no coverage across the codebase
- Strengthens 5 existing weak-assertion tests with behavioral checks
- No production code changes — test-only additions

## Changes

- `spec/ocak/claude_runner_spec.rb` — malformed JSON line skipping in `extract_result_from_stream`
- `spec/ocak/commands/hiz_spec.rb` — `create_branch` failure raises RuntimeError
- `spec/ocak/git_utils_spec.rb` — strengthen nil logger assertions
- `spec/ocak/issue_fetcher_spec.rb` — JSON parse error in `fetch_pr_comments` and `view`
- `spec/ocak/logger_spec.rb` — debug suppression in non-verbose mode, info display in quiet mode
- `spec/ocak/merge_manager_spec.rb` — `resolve_conflicts_via_agent` with empty conflict list
- `spec/ocak/merge_orchestration_spec.rb` — `post_audit_comment_single` with nil PR
- `spec/ocak/pipeline_executor_spec.rb` — `write_step_output` File.write failure; strengthen shutdown assertion
- `spec/ocak/pipeline_runner_spec.rb` — `process_one_issue` unexpected error, `cleanup_stale_worktrees` error, strengthen shutdown assertions
- `spec/ocak/pipeline_state_spec.rb` — `list` with corrupt file warns and skips
- `spec/ocak/process_runner_spec.rb` — `kill_process` Errno::ESRCH; strengthen nil registry assertion
- `spec/ocak/reready_processor_spec.rb` — retry-succeeds path (attempt 1 fails, attempt 2 passes)
- `spec/ocak/run_report_spec.rb` — `to_h` with nil `finished_at`
- `spec/ocak/stack_detector_spec.rb` — `pkg_has?` with malformed package.json

## Testing

- `bundle exec rspec` — 700 examples, 0 failures
- `bundle exec rubocop -A` — 70 files inspected, no offenses detected