### PR TITLE
fix(init): rescue JSON::ParserError when parsing settings.json

### DIFF
--- a/lib/ocak/commands/init.rb
+++ b/lib/ocak/commands/init.rb
@@ -85,7 +85,12 @@ module Ocak
 
       def update_settings(project_dir, stack)
         settings_path = File.join(project_dir, '.claude', 'settings.json')
-        existing = File.exist?(settings_path) ? JSON.parse(File.read(settings_path)) : {}
+        existing = begin
+          File.exist?(settings_path) ? JSON.parse(File.read(settings_path)) : {}
+        rescue JSON::ParserError
+          puts '  Warning: .claude/settings.json is not valid JSON, creating fresh'
+          {}
+        end
 
         merge_permissions(existing, stack)
         merge_hooks(existing)

--- a/spec/ocak/commands/init_spec.rb
+++ b/spec/ocak/commands/init_spec.rb
@@ -97,6 +97,19 @@ RSpec.describe Ocak::Commands::Init do
     expect(settings['permissions']['allow']).to include('Bash(bundle exec rspec*)')
   end
 
+  it 'recovers from malformed settings.json with a warning' do
+    settings_dir = File.join(dir, '.claude')
+    FileUtils.mkdir_p(settings_dir)
+    File.write(File.join(settings_dir, 'settings.json'), '{invalid json!!!}')
+
+    expect { command.call }.to output(
+      %r{Warning: .claude/settings.json is not valid JSON, creating fresh.*Ocak initialized}m
+    ).to_stdout
+
+    settings = JSON.parse(File.read(File.join(settings_dir, 'settings.json')))
+    expect(settings['permissions']['allow']).to include('Bash(bundle exec rspec*)')
+  end
+
   it 'updates .gitignore' do
     command.call
 


### PR DESCRIPTION
## Summary

Closes #105

- Rescue `JSON::ParserError` in `update_settings` so a malformed `.claude/settings.json` does not crash the `init` command
- Print a user-friendly warning and fall through with `{}` so init continues normally
- Add test coverage for the malformed JSON case in `init_spec.rb`

## Changes

- `lib/ocak/commands/init.rb` — wrap `JSON.parse` in a `begin/rescue JSON::ParserError` block
- `spec/ocak/commands/init_spec.rb` — new example asserting init completes and prints a warning when `settings.json` is invalid JSON

## Testing

- `bundle exec rspec` — passed (710 examples, 0 failures)
- `bundle exec rubocop -A` — passed (no offenses)