### PR TITLE
chore(step_comments): fix indentation in step_comments.rb and spec

### DIFF
--- a/lib/ocak/step_comments.rb
+++ b/lib/ocak/step_comments.rb
@@ -6,7 +6,7 @@ module Ocak
   # All methods accept an optional `issues:` keyword to override @issues, allowing
   # callers like Hiz to pass issues from a different source (e.g., state.issues).
   module StepComments
-def post_step_comment(issue_number, body, issues: @issues)
+    def post_step_comment(issue_number, body, issues: @issues)
       issues&.comment(issue_number, body)
     rescue StandardError => e
       @logger&.debug("Step comment failed: #{e.message}")

--- a/spec/ocak/step_comments_spec.rb
+++ b/spec/ocak/step_comments_spec.rb
@@ -47,29 +47,29 @@ RSpec.describe Ocak::StepComments do
       expect(instance.post_step_comment(42, 'hello')).to be_nil
     end
 
-it 'uses explicit issues: override instead of @issues' do
-  override = instance_double(Ocak::IssueFetcher, comment: nil)
+    it 'uses explicit issues: override instead of @issues' do
+      override = instance_double(Ocak::IssueFetcher, comment: nil)
 
-  instance.post_step_comment(42, 'hello', issues: override)
+      instance.post_step_comment(42, 'hello', issues: override)
 
-  expect(override).to have_received(:comment).with(42, 'hello')
-  expect(issues).not_to have_received(:comment)
-end
+      expect(override).to have_received(:comment).with(42, 'hello')
+      expect(issues).not_to have_received(:comment)
+    end
 
-it 'logs debug message when comment posting fails' do
-  allow(issues).to receive(:comment).and_raise(StandardError, 'network error')
+    it 'logs debug message when comment posting fails' do
+      allow(issues).to receive(:comment).and_raise(StandardError, 'network error')
 
-  instance.post_step_comment(42, 'hello')
+      instance.post_step_comment(42, 'hello')
 
-  expect(logger).to have_received(:debug).with('Step comment failed: network error')
-end
+      expect(logger).to have_received(:debug).with('Step comment failed: network error')
+    end
 
-it 'does not crash when @logger is nil and comment posting fails' do
-  instance.logger = nil
-  allow(issues).to receive(:comment).and_raise(StandardError, 'network error')
+    it 'does not crash when @logger is nil and comment posting fails' do
+      instance.logger = nil
+      allow(issues).to receive(:comment).and_raise(StandardError, 'network error')
 
-  expect { instance.post_step_comment(42, 'hello') }.not_to raise_error
-end
+      expect { instance.post_step_comment(42, 'hello') }.not_to raise_error
+    end
   end
 
   describe '#post_step_completion_comment' do


### PR DESCRIPTION
## Summary

- Fixes indentation of `post_step_comment` method definition in `step_comments.rb`
- Fixes indentation of test cases in `step_comments_spec.rb`

## Changes

- `lib/ocak/step_comments.rb` — correct indentation for `post_step_comment` method
- `spec/ocak/step_comments_spec.rb` — correct indentation for three test cases

## Testing

- `bundle exec rspec` — passed (736 examples, 0 failures)
- `bundle exec rubocop -A` — passed (no offenses)