### PR TITLE
feat(pipeline_runner): make poll interval sleep interruptible for faster shutdown

### DIFF
--- a/lib/ocak/pipeline_runner.rb
+++ b/lib/ocak/pipeline_runner.rb
@@ -114,7 +114,11 @@ module Ocak
         break if @options[:once]
 
         logger.info("Sleeping #{@config.poll_interval}s...")
-        sleep @config.poll_interval
+        @config.poll_interval.times do
+          break if @shutting_down
+
+          sleep 1
+        end
       end
     end
 


### PR DESCRIPTION
## Summary

Closes #139

- Replace the blocking `sleep @config.poll_interval` call in `run_loop` with a short-sleep loop that checks `@shutting_down` each second
- This allows graceful shutdown to respond within ~1 second instead of up to 60 seconds

## Changes

- `lib/ocak/pipeline_runner.rb` — replaced single `sleep` with interruptible loop in `run_loop`
- `spec/ocak/pipeline_runner_spec.rb` — added spec confirming sleep breaks early when `@shutting_down` is set

## Testing

- `bundle exec rspec` — 737 examples, 0 failures
- `bundle exec rubocop -A` — 70 files inspected, no offenses detected