### PR TITLE
feat(hiz): add label transition at pipeline start to prevent concurrent processing

### DIFF
--- a/lib/ocak/commands/hiz.rb
+++ b/lib/ocak/commands/hiz.rb
@@ -78,6 +78,7 @@ module Ocak
         start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
         chdir = @config.project_dir
 
+        issues.transition(issue_number, from: @config.label_ready, to: @config.label_in_progress)
         post_hiz_start_comment(issue_number, state: state)
         begin
           branch = create_branch(issue_number, chdir)
@@ -238,7 +239,7 @@ module Ocak
 
       def handle_failure(issue_number, phase, output, issues:, logger:)
         logger.error("Issue ##{issue_number} failed at phase: #{phase}")
-        issues.transition(issue_number, from: nil, to: @config.label_failed)
+        issues.transition(issue_number, from: @config.label_in_progress, to: @config.label_failed)
         issues.comment(issue_number,
                        "Hiz (fast mode) failed at phase: #{phase}\n\n```\n#{output.to_s[0..1000]}\n```")
         warn "Issue ##{issue_number} failed at phase: #{phase}"


### PR DESCRIPTION
## Summary

Closes #147

- Adds `label_in_progress` transition at the start of `run_fast_pipeline` to prevent concurrent `ocak run` processes from picking up the same issue
- Ensures `handle_failure` transitions from `label_in_progress` (not `nil`) to `label_failed` for correct label state
- Adds specs covering both the new start-of-pipeline transition and the updated failure transition

## Changes

- `lib/ocak/commands/hiz.rb` — added `issues.transition` call before `create_branch`; updated `handle_failure` to transition from `label_in_progress`
- `spec/ocak/commands/hiz_spec.rb` — added specs confirming label transitions at pipeline start and on failure

## Testing

- `bundle exec rspec` — 738 examples, 0 failures
- `bundle exec rubocop -A` — 70 files inspected, no offenses detected