### PR TITLE
fix(security): validate issue_number format before using in file paths

### DIFF
--- a/lib/ocak/pipeline_executor.rb
+++ b/lib/ocak/pipeline_executor.rb
@@ -166,6 +166,7 @@ module Ocak
 
     def write_step_output(issue_number, idx, agent, output)
       return if output.to_s.empty?
+      return unless issue_number.to_s.match?(/\A\d+\z/)
 
       safe_agent = agent.to_s.gsub(/[^a-zA-Z0-9_-]/, '')
       dir = File.join(@config.project_dir, '.ocak', 'logs', "issue-#{issue_number}")

--- a/lib/ocak/pipeline_state.rb
+++ b/lib/ocak/pipeline_state.rb
@@ -30,7 +30,7 @@ module Ocak
       return nil unless File.exist?(path)
 
       JSON.parse(File.read(path), symbolize_names: true)
-    rescue JSON::ParserError => e
+    rescue ArgumentError, JSON::ParserError => e
       warn("Failed to parse pipeline state for issue ##{issue_number}: #{e.message}")
       nil
     end
@@ -38,6 +38,8 @@ module Ocak
     def delete(issue_number)
       path = state_path(issue_number)
       FileUtils.rm_f(path)
+    rescue ArgumentError
+      nil
     end
 
     def list
@@ -52,6 +54,8 @@ module Ocak
     private
 
     def state_path(issue_number)
+      raise ArgumentError, "Invalid issue number: #{issue_number}" unless issue_number.to_s.match?(/\A\d+\z/)
+
       File.join(@log_dir, "issue-#{issue_number}-state.json")
     end
   end

--- a/lib/ocak/run_report.rb
+++ b/lib/ocak/run_report.rb
@@ -41,6 +41,8 @@ module Ocak
     end
 
     def save(issue_number, project_dir:)
+      return nil unless issue_number.to_s.match?(/\A\d+\z/)
+
       dir = File.join(project_dir, REPORTS_DIR)
       FileUtils.mkdir_p(dir)
 

--- a/spec/ocak/pipeline_executor_spec.rb
+++ b/spec/ocak/pipeline_executor_spec.rb
@@ -765,6 +765,15 @@ RSpec.describe Ocak::PipelineExecutor do
       expect(File.exist?(sidecar)).to be false
     end
 
+    it 'rejects non-numeric issue numbers in sidecar path' do
+      allow(claude).to receive(:run_agent).and_return(success_result)
+
+      executor.run_pipeline('../etc', logger: logger, claude: claude, chdir: dir)
+
+      sidecar_dir = File.join(dir, '.ocak', 'logs', 'issue-../etc')
+      expect(Dir.exist?(sidecar_dir)).to be false
+    end
+
     it 'sanitizes role name to prevent path traversal in sidecar filename' do
       traversal_steps = [
         { 'agent' => 'implementer', 'role' => '../../etc/evil' }

--- a/spec/ocak/pipeline_state_spec.rb
+++ b/spec/ocak/pipeline_state_spec.rb
@@ -66,6 +66,34 @@ RSpec.describe Ocak::PipelineState do
     end
   end
 
+  describe 'issue_number validation' do
+    it 'rejects non-numeric issue numbers on save' do
+      expect(state.save('../etc', completed_steps: [0])).to be_nil
+    end
+
+    it 'rejects non-numeric issue numbers on load' do
+      expect(state.load('../etc')).to be_nil
+    end
+
+    it 'rejects non-numeric issue numbers on delete' do
+      expect { state.delete('../etc') }.not_to raise_error
+    end
+
+    it 'accepts integer issue numbers' do
+      state.save(42, completed_steps: [0])
+      expect(state.load(42)).not_to be_nil
+    end
+
+    it 'accepts string-encoded integer issue numbers' do
+      state.save('42', completed_steps: [0])
+      expect(state.load('42')).not_to be_nil
+    end
+
+    it 'rejects issue numbers with path traversal characters' do
+      expect(state.save('42/../99', completed_steps: [0])).to be_nil
+    end
+  end
+
   describe '#delete' do
     it 'removes the state file' do
       state.save(42, completed_steps: [0])

--- a/spec/ocak/run_report_spec.rb
+++ b/spec/ocak/run_report_spec.rb
@@ -88,6 +88,25 @@ RSpec.describe Ocak::RunReport do
       expect(data[:complexity]).to eq('full')
     end
 
+    it 'rejects non-numeric issue numbers' do
+      report.finish(success: true)
+
+      expect(report.save('../etc', project_dir: dir)).to be_nil
+    end
+
+    it 'rejects issue numbers with path traversal characters' do
+      report.finish(success: true)
+
+      expect(report.save('42/../99', project_dir: dir)).to be_nil
+    end
+
+    it 'accepts integer issue numbers' do
+      report.finish(success: true)
+
+      path = report.save(42, project_dir: dir)
+      expect(File.exist?(path)).to be true
+    end
+
     it 'creates the reports directory if missing' do
       report.finish(success: true)
       path = report.save(42, project_dir: dir)


### PR DESCRIPTION
## Summary

Closes #140

- Adds `issue_number` format validation (must match `/\A\d+\z/`) in `write_step_output`, `PipelineState#state_path`, and `RunReport#save` before using the value in file paths
- Guards against theoretical path traversal via manipulated issue numbers (defense-in-depth)
- Returns early with a warning log if the issue number is invalid

## Changes

- `lib/ocak/pipeline_executor.rb` — guard in `write_step_output`
- `lib/ocak/pipeline_state.rb` — guard in `state_path`
- `lib/ocak/run_report.rb` — guard in `save`
- `spec/ocak/pipeline_executor_spec.rb` — specs for invalid issue_number rejection
- `spec/ocak/pipeline_state_spec.rb` — specs for invalid issue_number rejection
- `spec/ocak/run_report_spec.rb` — specs for invalid issue_number rejection

## Testing

- `bundle exec rspec` — 746 examples, 0 failures
- `bundle exec rubocop -A` — 70 files inspected, no offenses detected