### PR TITLE
fix(pipeline_runner): narrow rescue in process_one_issue to surface programming bugs

### DIFF
--- a/spec/ocak/pipeline_runner_spec.rb
+++ b/spec/ocak/pipeline_runner_spec.rb
@@ -1049,7 +1049,7 @@ RSpec.describe Ocak::PipelineRunner do
 
       runner.run
 
-      expect(logger).to have_received(:debug).with(/Full backtrace:/)
+      expect(logger).to have_received(:debug).with(/Full backtrace:.*pipeline_runner/m)
     end
 
     it 're-raises NameError after cleanup' do
@@ -1065,6 +1065,7 @@ RSpec.describe Ocak::PipelineRunner do
 
       expect { runner.run }.to raise_error(TypeError, 'no implicit conversion')
       expect(issues).to have_received(:transition).with(1, from: 'in-progress', to: 'pipeline-failed')
+      expect(issues).to have_received(:comment).with(1, /TypeError/)
     end
 
     it 'does not re-raise recoverable StandardError' do
@@ -1072,6 +1073,74 @@ RSpec.describe Ocak::PipelineRunner do
 
       expect { runner.run }.not_to raise_error
       expect(issues).to have_received(:transition).with(1, from: 'in-progress', to: 'pipeline-failed')
+    end
+
+    it 'returns error result when issues.comment raises during handle_process_error' do
+      allow(claude).to receive(:run_agent).and_raise(RuntimeError, 'original error')
+      allow(issues).to receive(:comment).and_raise(StandardError, 'GitHub API down')
+
+      expect { runner.run }.not_to raise_error
+      expect(issues).to have_received(:transition).with(1, from: 'in-progress', to: 'pipeline-failed')
+    end
+  end
+
+  describe 'multi-issue batch with programming error' do
+    subject(:runner) { described_class.new(config: config, options: { once: true }) }
+
+    let(:worktree1) do
+      Ocak::WorktreeManager::Worktree.new(
+        path: '/project/.claude/worktrees/issue-1',
+        branch: 'auto/issue-1-abc',
+        issue_number: 1
+      )
+    end
+    let(:worktree2) do
+      Ocak::WorktreeManager::Worktree.new(
+        path: '/project/.claude/worktrees/issue-2',
+        branch: 'auto/issue-2-def',
+        issue_number: 2
+      )
+    end
+    let(:worktree_manager) { instance_double(Ocak::WorktreeManager, clean_stale: []) }
+    let(:merger) { instance_double(Ocak::MergeManager) }
+
+    before do
+      allow(Ocak::WorktreeManager).to receive(:new).and_return(worktree_manager)
+      allow(Ocak::MergeManager).to receive(:new).and_return(merger)
+      allow(Ocak::IssueFetcher).to receive(:new).and_return(issues)
+      allow(issues).to receive(:fetch_ready).and_return([
+                                                          { 'number' => 1, 'title' => 'A' },
+                                                          { 'number' => 2, 'title' => 'B' }
+                                                        ])
+      allow(issues).to receive(:transition)
+      allow(issues).to receive(:comment)
+      allow(worktree_manager).to receive(:remove)
+      allow(worktree_manager).to receive(:create) do |num, **_opts|
+        num == 1 ? worktree1 : worktree2
+      end
+    end
+
+    it 'cleans up all worktrees and merges successful issues before re-raising' do
+      planner_output = '{"batches": [{"batch": 1, "issues": [' \
+                       '{"number": 1, "title": "A", "complexity": "full"}, ' \
+                       '{"number": 2, "title": "B", "complexity": "full"}]}]}'
+      planner_result = Ocak::ClaudeRunner::AgentResult.new(success: true, output: planner_output)
+
+      allow(claude).to receive(:run_agent) do |agent, prompt, **_opts|
+        if agent == 'planner'
+          planner_result
+        elsif prompt.include?('#1')
+          raise NameError, 'undefined local variable'
+        else
+          success_result
+        end
+      end
+      allow(merger).to receive(:merge).and_return(true)
+
+      expect { runner.run }.to raise_error(NameError, 'undefined local variable')
+      expect(worktree_manager).to have_received(:remove).with(worktree1)
+      expect(worktree_manager).to have_received(:remove).with(worktree2)
+      expect(merger).to have_received(:merge).with(2, worktree2)
     end
   end
 


### PR DESCRIPTION
## Summary

Closes #137

- Narrowed the `rescue StandardError` in `process_one_issue` to re-raise non-recoverable programming errors (`NameError`, `NoMethodError`, `TypeError`) so they surface as real bugs instead of being silently marked as `pipeline-failed`
- Included the error class name in the GitHub failure comment (`Unexpected #{e.class}: #{e.message}`)
- Deferred the re-raise until after batch cleanup to ensure labels are reset and worktrees are cleaned up on programming errors

## Changes

- `lib/ocak/pipeline_runner.rb` — Updated `process_one_issue` rescue block to re-raise programming errors after cleanup
- `spec/ocak/pipeline_runner_spec.rb` — Added specs confirming error class is included in failure comment and programming errors are re-raised

## Testing

- `bundle exec rspec` — 744 examples, 0 failures
- `bundle exec rubocop -A` — 70 files inspected, no offenses detected