### PR TITLE
chore: gitignore local issue store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@
 logs/pipeline/
 .ocak/logs/
 .ocak/reports/
+.ocak/issues/


### PR DESCRIPTION
## Summary
- Add `.ocak/issues/` to `.gitignore` to keep local issue store out of version control

🤖 Generated with [Claude Code](https://claude.com/claude-code)