### PR TITLE
feat(core): add ProjectKey module to resolve owner/repo from git remote

### DIFF
--- a/lib/ocak/project_key.rb
+++ b/lib/ocak/project_key.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'open3'
+
+module Ocak
+  module ProjectKey
+    class NoRemoteError < StandardError; end
+
+    # Resolve owner/repo from git remote origin.
+    # Returns a string like "owner/repo".
+    # Raises NoRemoteError if no remote or URL is unparseable.
+    def self.resolve(dir = Dir.pwd)
+      url = fetch_remote_url(dir)
+      parse_url(url)
+    end
+
+    def self.fetch_remote_url(dir)
+      stdout, _stderr, status = Open3.capture3('git', 'remote', 'get-url', 'origin', chdir: dir)
+      raise NoRemoteError, "No git remote 'origin' found in #{dir}" unless status.success?
+
+      stdout.strip
+    end
+    private_class_method :fetch_remote_url
+
+    def self.parse_url(url)
+      # Matches both SSH and HTTPS patterns:
+      #   git@github.com:owner/repo.git     → owner, repo
+      #   https://github.com/owner/repo.git → owner, repo
+      #   https://github.com/owner/repo     → owner, repo
+      if (match = url.match(%r{[/:]([\w.-]+)/([\w.-]+?)(?:\.git)?$}))
+        "#{match[1]}/#{match[2]}"
+      else
+        raise NoRemoteError, "Cannot parse owner/repo from remote URL: #{url}"
+      end
+    end
+    private_class_method :parse_url
+  end
+end

--- a/spec/ocak/project_key_spec.rb
+++ b/spec/ocak/project_key_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Ocak::ProjectKey do
+  describe '.resolve' do
+    def stub_remote(url, success: true)
+      status = instance_double(Process::Status, success?: success)
+      allow(Open3).to receive(:capture3)
+        .with('git', 'remote', 'get-url', 'origin', chdir: anything)
+        .and_return([url, '', status])
+    end
+
+    it 'parses SSH URL' do
+      stub_remote("git@github.com:clayharmon/ocak.git\n")
+      expect(described_class.resolve('/tmp')).to eq('clayharmon/ocak')
+    end
+
+    it 'parses HTTPS URL with .git' do
+      stub_remote("https://github.com/clayharmon/ocak.git\n")
+      expect(described_class.resolve('/tmp')).to eq('clayharmon/ocak')
+    end
+
+    it 'parses HTTPS URL without .git' do
+      stub_remote("https://github.com/owner/repo\n")
+      expect(described_class.resolve('/tmp')).to eq('owner/repo')
+    end
+
+    it 'works with non-GitHub hosts' do
+      stub_remote("git@gitlab.com:org/project.git\n")
+      expect(described_class.resolve('/tmp')).to eq('org/project')
+    end
+
+    it 'raises NoRemoteError when git command fails' do
+      stub_remote('', success: false)
+      expect { described_class.resolve('/tmp') }.to raise_error(described_class::NoRemoteError)
+    end
+
+    it 'raises NoRemoteError for unparseable URL' do
+      stub_remote("not-a-valid-url\n")
+      expect { described_class.resolve('/tmp') }.to raise_error(described_class::NoRemoteError)
+    end
+
+    it 'defaults dir to Dir.pwd' do
+      stub_remote("git@github.com:a/b.git\n")
+      allow(Dir).to receive(:pwd).and_return('/tmp')
+      expect(described_class.resolve).to eq('a/b')
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,7 @@ require 'ocak/stream_parser'
 require 'ocak/claude_runner'
 require 'ocak/pipeline_executor'
 require 'ocak/git_utils'
+require 'ocak/project_key'
 require 'ocak/reready_processor'
 require 'ocak/logger'
 


### PR DESCRIPTION
## Summary

Closes #177

Implements a new `ProjectKey` module that extracts the repository owner and name from git remote URLs. This provides a deterministic key for namespacing issues per repository in the global issue store at `~/.ocak/issues/`.

- Supports both SSH (`git@github.com:owner/repo.git`) and HTTPS (`https://github.com/owner/repo.git`) URL formats
- Works with any git host (GitHub, GitLab, Bitbucket, etc.)
- Raises `ProjectKey::NoRemoteError` when remote is missing or URL is unparseable
- Includes comprehensive test coverage with Open3 mocking

## Changes

- **lib/ocak/project_key.rb** — New module with `.resolve(dir)` class method to parse owner/repo from git remote origin URLs
- **spec/ocak/project_key_spec.rb** — Comprehensive tests covering SSH/HTTPS formats, non-GitHub hosts, error cases, and default dir parameter
- **spec/spec_helper.rb** — Add require for new ProjectKey module

## Testing

- `bundle exec rspec` — 839 examples, 0 failures ✅
- `bundle exec rubocop -A` — 83 files inspected, no offenses detected ✅