### PR TITLE
fix(worktree): validate issue_number in WorktreeManager#create

### DIFF
--- a/lib/ocak/worktree_manager.rb
+++ b/lib/ocak/worktree_manager.rb
@@ -16,6 +16,8 @@ module Ocak
 
     def create(issue_number, setup_command: nil)
       @mutex.synchronize do
+        raise ArgumentError, "Invalid issue number: #{issue_number}" unless issue_number.to_s.match?(/\A\d+\z/)
+
         FileUtils.mkdir_p(@worktree_base)
 
         branch = "auto/issue-#{issue_number}-#{SecureRandom.hex(4)}"

--- a/spec/ocak/worktree_manager_spec.rb
+++ b/spec/ocak/worktree_manager_spec.rb
@@ -25,6 +25,22 @@ RSpec.describe Ocak::WorktreeManager do
       expect(worktree.issue_number).to eq(42)
     end
 
+    it 'raises ArgumentError for path traversal issue numbers' do
+      expect { manager.create('../evil') }.to raise_error(ArgumentError, /Invalid issue number/)
+    end
+
+    it 'raises ArgumentError for shell metacharacter issue numbers' do
+      expect { manager.create('123; rm') }.to raise_error(ArgumentError, /Invalid issue number/)
+    end
+
+    it 'raises ArgumentError for nil issue numbers' do
+      expect { manager.create(nil) }.to raise_error(ArgumentError, /Invalid issue number/)
+    end
+
+    it 'raises ArgumentError for empty string issue numbers' do
+      expect { manager.create('') }.to raise_error(ArgumentError, /Invalid issue number/)
+    end
+
     it 'raises on failure' do
       allow(FileUtils).to receive(:mkdir_p)
       allow(Open3).to receive(:capture3)


### PR DESCRIPTION
## Summary

Closes #195

- Adds input validation to `WorktreeManager#create` to ensure `issue_number` contains only digits
- Prevents potential path traversal via crafted issue numbers in branch names and filesystem paths
- Aligns with validation pattern already used in `PipelineState` and `StateManagement`

## Changes

- **lib/ocak/worktree_manager.rb**: Added `ArgumentError` validation at the start of `create` method to reject non-numeric issue numbers
- **spec/ocak/worktree_manager_spec.rb**: Added test cases for path traversal, shell metacharacters, nil, and valid integer inputs

## Testing

- `bundle exec rspec` — passed
- `bundle exec rubocop -A` — passed