### PR TITLE
fix(verification): check git diff exit status in scoped lint

### DIFF
--- a/lib/ocak/verification.rb
+++ b/lib/ocak/verification.rb
@@ -52,7 +52,12 @@ module Ocak
     end
 
     def run_scoped_lint(logger, chdir:)
-      changed_stdout, = Open3.capture3('git', 'diff', '--name-only', 'main', chdir: chdir)
+      changed_stdout, stderr, status = Open3.capture3('git', 'diff', '--name-only', 'main', chdir: chdir)
+      unless status.success?
+        logger&.warn("Scoped lint skipped — git diff failed: #{stderr[0..200]}")
+        return nil
+      end
+
       changed_files = changed_stdout.lines.map(&:strip).reject(&:empty?)
 
       extensions = lint_extensions_for(@config.language)

--- a/spec/ocak/verification_spec.rb
+++ b/spec/ocak/verification_spec.rb
@@ -81,6 +81,17 @@ RSpec.describe Ocak::Verification do
   end
 
   describe '#run_scoped_lint' do
+    it 'returns nil and logs warning when git diff fails' do
+      allow(Open3).to receive(:capture3)
+        .with('git', 'diff', '--name-only', 'main', chdir: chdir)
+        .and_return(['', 'fatal: ambiguous argument', instance_double(Process::Status, success?: false)])
+
+      result = host.run_scoped_lint(logger, chdir: chdir)
+
+      expect(result).to be_nil
+      expect(logger).to have_received(:warn).with(/Scoped lint skipped — git diff failed/)
+    end
+
     it 'returns nil when no changed files match lint extensions' do
       allow(Open3).to receive(:capture3)
         .with('git', 'diff', '--name-only', 'main', chdir: chdir)


### PR DESCRIPTION
## Summary

Closes #193

The `Verification` module now properly checks the exit status of `git diff --name-only main` in the scoped lint check. Previously, if the diff command failed (e.g., `main` doesn't exist in worktree), the error was silently discarded and the lint would pass with no files checked.

## Changes

- **lib/ocak/verification.rb**: Capture and check `git diff` exit status; log warning and return `nil` on failure
- **spec/ocak/verification_spec.rb**: Add test case for git diff failure scenario

## Testing

- `bundle exec rspec` — passed
- `bundle exec rubocop -A` — passed