### PR TITLE
test(modules): add unit tests for 6 core pipeline modules

### DIFF
--- a/spec/ocak/batch_processing_spec.rb
+++ b/spec/ocak/batch_processing_spec.rb
@@ -1,0 +1,282 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'ocak/batch_processing'
+require 'ocak/worktree_manager'
+
+RSpec.describe Ocak::BatchProcessing do
+  let(:test_class) do
+    Class.new do
+      include Ocak::BatchProcessing
+
+      public :process_issues, :run_batch, :process_one_issue, :build_issue_result
+
+      attr_accessor :shutting_down
+
+      def initialize(config:, options: {}, executor: nil)
+        @config = config
+        @options = options
+        @executor = executor
+        @shutting_down = false
+        @active_mutex = Mutex.new
+        @active_issues = []
+      end
+
+      def build_claude(_logger) = nil
+      def build_logger(**) = nil
+      def build_merge_manager(**) = nil
+      def run_pipeline(_issue_number, **_opts) = { success: true }
+      def merge_completed_issue(_result, merger:, issues:, logger:); end
+      def handle_interrupted_issue(_issue_number, _path, _phase, logger:, issues:); end
+      def report_pipeline_failure(_issue_number, _result, issues:, config:, logger:); end
+      def handle_process_error(_error, issue_number:, logger:, issues:); end
+    end
+  end
+
+  let(:config) do
+    instance_double(Ocak::Config,
+                    max_issues_per_run: 3,
+                    max_parallel: 2,
+                    label_ready: 'auto-ready',
+                    label_in_progress: 'in-progress',
+                    label_failed: 'pipeline-failed',
+                    setup_command: nil)
+  end
+  let(:logger) { instance_double(Ocak::PipelineLogger, info: nil, warn: nil, error: nil, debug: nil) }
+  let(:issues) { instance_double(Ocak::IssueFetcher, transition: nil, comment: nil) }
+  let(:executor) { double('executor') }
+  let(:worktree) { instance_double(Ocak::WorktreeManager::Worktree, path: '/worktrees/42', branch: 'auto/issue-42') }
+  let(:worktrees) { instance_double(Ocak::WorktreeManager, create: worktree, remove: nil) }
+
+  subject(:instance) { test_class.new(config: config, executor: executor) }
+
+  let(:ready_issue) { { 'number' => 42, 'title' => 'Fix bug' } }
+
+  describe '#process_issues' do
+    let(:batch) { { 'issues' => [ready_issue] } }
+
+    before do
+      allow(executor).to receive(:plan_batches).and_return([batch])
+      allow(instance).to receive(:run_batch)
+    end
+
+    it 'caps issues to max_issues_per_run' do
+      many_issues = (1..5).map { |n| { 'number' => n, 'title' => "Issue #{n}" } }
+      allow(executor).to receive(:plan_batches).and_return([{ 'issues' => many_issues[0...2] }])
+
+      instance.process_issues(many_issues, logger: logger, issues: issues)
+
+      expect(executor).to have_received(:plan_batches) do |issues_arg, **|
+        expect(issues_arg.size).to be <= 3
+      end
+    end
+
+    it 'logs warning when capping issues' do
+      many_issues = (1..5).map { |n| { 'number' => n, 'title' => "Issue #{n}" } }
+      allow(executor).to receive(:plan_batches).and_return([])
+
+      instance.process_issues(many_issues, logger: logger, issues: issues)
+
+      expect(logger).to have_received(:warn).with(/Capping to 3 issues/)
+    end
+
+    it 'logs batch info before running' do
+      instance.process_issues([ready_issue], logger: logger, issues: issues)
+      expect(logger).to have_received(:info).with(%r{Running batch 1/1})
+    end
+
+    it 'calls run_batch for each batch' do
+      instance.process_issues([ready_issue], logger: logger, issues: issues)
+      expect(instance).to have_received(:run_batch)
+    end
+
+    it 'logs dry run message and skips run_batch when dry_run option is set' do
+      host = test_class.new(config: config, options: { dry_run: true }, executor: executor)
+      allow(executor).to receive(:plan_batches).and_return([batch])
+      allow(host).to receive(:run_batch)
+
+      host.process_issues([ready_issue], logger: logger, issues: issues)
+
+      expect(host).not_to have_received(:run_batch)
+      expect(logger).to have_received(:info).with(/DRY RUN/)
+    end
+  end
+
+  describe '#run_batch' do
+    before do
+      allow(Ocak::WorktreeManager).to receive(:new).and_return(worktrees)
+      allow(instance).to receive(:process_one_issue).and_return(
+        { issue_number: 42, success: true, worktree: worktree }
+      )
+      allow(instance).to receive(:merge_completed_issue)
+      allow(instance).to receive(:build_merge_manager).and_return(nil)
+    end
+
+    it 'processes all issues and calls merge for successful ones' do
+      instance.run_batch([ready_issue], logger: logger, issues: issues)
+      expect(instance).to have_received(:merge_completed_issue)
+    end
+
+    it 'removes worktree for completed issues' do
+      instance.run_batch([ready_issue], logger: logger, issues: issues)
+      expect(worktrees).to have_received(:remove).with(worktree)
+    end
+
+    it 'skips merging when shutting_down is true' do
+      instance.shutting_down = true
+      instance.run_batch([ready_issue], logger: logger, issues: issues)
+      expect(instance).not_to have_received(:merge_completed_issue)
+    end
+
+    it 'skips worktree removal for interrupted results' do
+      allow(instance).to receive(:process_one_issue).and_return(
+        { issue_number: 42, success: false, worktree: worktree, interrupted: true }
+      )
+      instance.run_batch([ready_issue], logger: logger, issues: issues)
+      expect(worktrees).not_to have_received(:remove)
+    end
+
+    it 'logs warning when worktree removal fails' do
+      allow(worktrees).to receive(:remove).and_raise(StandardError, 'locked')
+      instance.run_batch([ready_issue], logger: logger, issues: issues)
+      expect(logger).to have_received(:warn).with(/Failed to clean worktree/)
+    end
+
+    it 'skips worktree removal when result has no worktree' do
+      allow(instance).to receive(:process_one_issue).and_return(
+        { issue_number: 42, success: false, worktree: nil }
+      )
+      instance.run_batch([ready_issue], logger: logger, issues: issues)
+      expect(worktrees).not_to have_received(:remove)
+    end
+
+    it 'raises programming error if one is present in results' do
+      error = NoMethodError.new('undefined method')
+      allow(instance).to receive(:process_one_issue).and_return(
+        { issue_number: 42, success: false, worktree: nil, programming_error: error }
+      )
+      expect { instance.run_batch([ready_issue], logger: logger, issues: issues) }.to raise_error(NoMethodError)
+    end
+  end
+
+  describe '#process_one_issue' do
+    let(:claude) { instance_double(Ocak::ClaudeRunner) }
+    let(:success_pipeline_result) { { success: true, interrupted: false } }
+
+    before do
+      allow(Ocak::WorktreeManager).to receive(:new).and_return(worktrees)
+      allow(instance).to receive(:build_logger).and_return(logger)
+      allow(instance).to receive(:build_claude).and_return(claude)
+      allow(instance).to receive(:run_pipeline).and_return(success_pipeline_result)
+      allow(instance).to receive(:build_issue_result).and_return(
+        { issue_number: 42, success: true, worktree: worktree }
+      )
+    end
+
+    it 'transitions issue to in-progress' do
+      instance.process_one_issue(ready_issue, worktrees: worktrees, issues: issues)
+      expect(issues).to have_received(:transition).with(42, from: 'auto-ready', to: 'in-progress')
+    end
+
+    it 'creates a worktree for the issue' do
+      instance.process_one_issue(ready_issue, worktrees: worktrees, issues: issues)
+      expect(worktrees).to have_received(:create).with(42, setup_command: nil)
+    end
+
+    it 'calls run_pipeline with the issue number' do
+      instance.process_one_issue(ready_issue, worktrees: worktrees, issues: issues)
+      expect(instance).to have_received(:run_pipeline).with(42, anything)
+    end
+
+    it 'uses simple complexity when fast option is set' do
+      host = test_class.new(config: config, options: { fast: true }, executor: executor)
+      allow(host).to receive(:build_logger).and_return(logger)
+      allow(host).to receive(:build_claude).and_return(claude)
+      allow(host).to receive(:run_pipeline).and_return(success_pipeline_result)
+      allow(host).to receive(:build_issue_result).and_return({ issue_number: 42, success: true, worktree: worktree })
+
+      host.process_one_issue(ready_issue, worktrees: worktrees, issues: issues)
+
+      expect(host).to have_received(:run_pipeline) do |_num, **opts|
+        expect(opts[:complexity]).to eq('simple')
+      end
+    end
+
+    it 'returns error result on StandardError' do
+      allow(instance).to receive(:run_pipeline).and_raise(StandardError, 'unexpected')
+      allow(instance).to receive(:handle_process_error)
+
+      result = instance.process_one_issue(ready_issue, worktrees: worktrees, issues: issues)
+
+      expect(result[:success]).to be false
+      expect(result[:error]).to eq('unexpected')
+    end
+
+    it 'marks NameError as programming_error' do
+      error = NoMethodError.new('undefined method')
+      allow(instance).to receive(:run_pipeline).and_raise(error)
+      allow(instance).to receive(:handle_process_error)
+
+      result = instance.process_one_issue(ready_issue, worktrees: worktrees, issues: issues)
+
+      expect(result[:programming_error]).to eq(error)
+    end
+
+    it 'removes issue from active_issues after processing' do
+      active_issues = instance.instance_variable_get(:@active_issues)
+      instance.process_one_issue(ready_issue, worktrees: worktrees, issues: issues)
+      expect(active_issues).not_to include(42)
+    end
+  end
+
+  describe '#build_issue_result' do
+    let(:issues) { instance_double(Ocak::IssueFetcher, transition: nil, comment: nil) }
+
+    before do
+      allow(instance).to receive(:handle_interrupted_issue)
+      allow(instance).to receive(:report_pipeline_failure)
+      allow(instance).to receive(:build_logger).and_return(logger)
+    end
+
+    it 'returns interrupted result when result is interrupted' do
+      result = { interrupted: true, phase: 'implement' }
+      outcome = instance.build_issue_result(result, issue_number: 42, worktree: worktree,
+                                                    issues: issues, logger: logger)
+      expect(outcome).to eq({ issue_number: 42, success: false, worktree: worktree, interrupted: true })
+    end
+
+    it 'calls handle_interrupted_issue when interrupted' do
+      result = { interrupted: true, phase: 'implement' }
+      instance.build_issue_result(result, issue_number: 42, worktree: worktree, issues: issues, logger: logger)
+      expect(instance).to have_received(:handle_interrupted_issue)
+        .with(42, worktree.path, 'implement', logger: logger, issues: issues)
+    end
+
+    it 'returns success result with audit info when result succeeds' do
+      result = { success: true, audit_blocked: false, audit_output: nil }
+      outcome = instance.build_issue_result(result, issue_number: 42, worktree: worktree,
+                                                    issues: issues, logger: logger)
+      expect(outcome).to include(issue_number: 42, success: true, worktree: worktree, audit_blocked: false)
+    end
+
+    it 'includes audit_blocked in success result' do
+      result = { success: true, audit_blocked: true, audit_output: '🔴 blocked' }
+      outcome = instance.build_issue_result(result, issue_number: 42, worktree: worktree,
+                                                    issues: issues, logger: logger)
+      expect(outcome[:audit_blocked]).to be true
+    end
+
+    it 'calls report_pipeline_failure when result fails' do
+      result = { success: false, phase: 'implement', output: 'Error' }
+      instance.build_issue_result(result, issue_number: 42, worktree: worktree, issues: issues, logger: logger)
+      expect(instance).to have_received(:report_pipeline_failure)
+    end
+
+    it 'returns failure result without audit info when result fails' do
+      result = { success: false, phase: 'implement', output: 'Error' }
+      outcome = instance.build_issue_result(result, issue_number: 42, worktree: worktree,
+                                                    issues: issues, logger: logger)
+      expect(outcome).to eq({ issue_number: 42, success: false, worktree: worktree })
+    end
+  end
+end

--- a/spec/ocak/instance_builders_spec.rb
+++ b/spec/ocak/instance_builders_spec.rb
@@ -1,0 +1,200 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'ocak/instance_builders'
+
+RSpec.describe Ocak::InstanceBuilders do
+  let(:test_class) do
+    Class.new do
+      include Ocak::InstanceBuilders
+
+      public :build_logger, :build_claude, :build_merge_manager,
+             :gh_available?, :cleanup_stale_worktrees, :ensure_labels
+
+      def initialize(config:, options: {}, watch_formatter: nil, registry: nil)
+        @config = config
+        @options = options
+        @watch_formatter = watch_formatter
+        @registry = registry
+      end
+    end
+  end
+
+  let(:config) do
+    instance_double(Ocak::Config,
+                    project_dir: '/project',
+                    log_dir: 'logs/pipeline')
+  end
+  let(:logger) { instance_double(Ocak::PipelineLogger, info: nil, warn: nil, error: nil, debug: nil) }
+  let(:registry) { instance_double(Ocak::ProcessRegistry) }
+  let(:issues) { instance_double(Ocak::IssueFetcher) }
+
+  subject(:instance) { test_class.new(config: config, registry: registry) }
+
+  describe '#build_logger' do
+    before { allow(Ocak::PipelineLogger).to receive(:new).and_return(logger) }
+
+    it 'creates a PipelineLogger with config log_dir' do
+      instance.build_logger
+      expect(Ocak::PipelineLogger).to have_received(:new)
+        .with(hash_including(log_dir: '/project/logs/pipeline'))
+    end
+
+    it 'passes issue_number when provided' do
+      instance.build_logger(issue_number: 42)
+      expect(Ocak::PipelineLogger).to have_received(:new)
+        .with(hash_including(issue_number: 42))
+    end
+
+    it 'defaults log_level to :normal when not in options' do
+      instance.build_logger
+      expect(Ocak::PipelineLogger).to have_received(:new)
+        .with(hash_including(log_level: :normal))
+    end
+
+    it 'uses log_level from options when present' do
+      host = test_class.new(config: config, options: { log_level: :verbose })
+      host.build_logger
+      expect(Ocak::PipelineLogger).to have_received(:new)
+        .with(hash_including(log_level: :verbose))
+    end
+
+    it 'returns the logger instance' do
+      result = instance.build_logger
+      expect(result).to eq(logger)
+    end
+  end
+
+  describe '#build_claude' do
+    let(:claude) { instance_double(Ocak::ClaudeRunner) }
+
+    before { allow(Ocak::ClaudeRunner).to receive(:new).and_return(claude) }
+
+    it 'creates a ClaudeRunner with config and logger' do
+      instance.build_claude(logger)
+      expect(Ocak::ClaudeRunner).to have_received(:new)
+        .with(hash_including(config: config, logger: logger))
+    end
+
+    it 'passes registry to ClaudeRunner' do
+      instance.build_claude(logger)
+      expect(Ocak::ClaudeRunner).to have_received(:new)
+        .with(hash_including(registry: registry))
+    end
+
+    it 'returns the claude runner instance' do
+      result = instance.build_claude(logger)
+      expect(result).to eq(claude)
+    end
+
+    it 'passes watch_formatter when set' do
+      watch = instance_double(Ocak::WatchFormatter)
+      host = test_class.new(config: config, watch_formatter: watch)
+      host.build_claude(logger)
+      expect(Ocak::ClaudeRunner).to have_received(:new)
+        .with(hash_including(watch: watch))
+    end
+  end
+
+  describe '#build_merge_manager' do
+    let(:claude) { instance_double(Ocak::ClaudeRunner) }
+    let(:merge_manager) { instance_double(Ocak::MergeManager) }
+    let(:local_merge_manager) { instance_double(Ocak::LocalMergeManager) }
+
+    before do
+      allow(Ocak::MergeManager).to receive(:new).and_return(merge_manager)
+      allow(Ocak::LocalMergeManager).to receive(:new).and_return(local_merge_manager)
+      allow(Ocak::ClaudeRunner).to receive(:new).and_return(claude)
+    end
+
+    it 'builds MergeManager for regular IssueFetcher' do
+      result = instance.build_merge_manager(logger: logger, issues: issues)
+      expect(result).to eq(merge_manager)
+    end
+
+    it 'builds LocalMergeManager when issues is LocalIssueFetcher and gh unavailable' do
+      local_issues = Ocak::LocalIssueFetcher.new(config: config)
+      allow(Open3).to receive(:capture3).and_return(['', '', instance_double(Process::Status, success?: false)])
+
+      result = instance.build_merge_manager(logger: logger, issues: local_issues)
+      expect(result).to eq(local_merge_manager)
+    end
+
+    it 'builds MergeManager when issues is LocalIssueFetcher but gh is available' do
+      local_issues = Ocak::LocalIssueFetcher.new(config: config)
+      allow(Open3).to receive(:capture3).and_return(['ok', '', instance_double(Process::Status, success?: true)])
+
+      result = instance.build_merge_manager(logger: logger, issues: local_issues)
+      expect(result).to eq(merge_manager)
+    end
+  end
+
+  describe '#gh_available?' do
+    it 'returns true when gh command succeeds' do
+      allow(Open3).to receive(:capture3)
+        .with('gh', 'repo', 'view', '--json', 'name', chdir: '/project')
+        .and_return(['ok', '', instance_double(Process::Status, success?: true)])
+
+      expect(instance.gh_available?).to be true
+    end
+
+    it 'returns false when gh command fails' do
+      allow(Open3).to receive(:capture3)
+        .with('gh', 'repo', 'view', '--json', 'name', chdir: '/project')
+        .and_return(['', 'error', instance_double(Process::Status, success?: false)])
+
+      expect(instance.gh_available?).to be false
+    end
+
+    it 'returns false when gh is not installed (Errno::ENOENT)' do
+      allow(Open3).to receive(:capture3).and_raise(Errno::ENOENT)
+
+      expect(instance.gh_available?).to be false
+    end
+  end
+
+  describe '#cleanup_stale_worktrees' do
+    let(:worktrees) { instance_double(Ocak::WorktreeManager, clean_stale: []) }
+
+    before { allow(Ocak::WorktreeManager).to receive(:new).and_return(worktrees) }
+
+    it 'calls clean_stale on WorktreeManager' do
+      instance.cleanup_stale_worktrees(logger)
+      expect(worktrees).to have_received(:clean_stale)
+    end
+
+    it 'logs each removed worktree path' do
+      allow(worktrees).to receive(:clean_stale).and_return(['/path/to/wt1', '/path/to/wt2'])
+      instance.cleanup_stale_worktrees(logger)
+      expect(logger).to have_received(:info).with(/wt1/)
+      expect(logger).to have_received(:info).with(/wt2/)
+    end
+
+    it 'swallows StandardError and logs warning' do
+      allow(worktrees).to receive(:clean_stale).and_raise(StandardError, 'git error')
+      expect { instance.cleanup_stale_worktrees(logger) }.not_to raise_error
+      expect(logger).to have_received(:warn).with(/Stale worktree cleanup failed/)
+    end
+  end
+
+  describe '#ensure_labels' do
+    before { allow(issues).to receive(:ensure_labels) }
+
+    it 'calls ensure_labels with all_labels from config' do
+      all_labels = %w[auto-ready in-progress completed failed]
+      allow(config).to receive(:all_labels).and_return(all_labels)
+
+      instance.ensure_labels(issues, logger)
+
+      expect(issues).to have_received(:ensure_labels).with(all_labels)
+    end
+
+    it 'swallows StandardError and logs warning' do
+      allow(config).to receive(:all_labels).and_return([])
+      allow(issues).to receive(:ensure_labels).and_raise(StandardError, 'API error')
+
+      expect { instance.ensure_labels(issues, logger) }.not_to raise_error
+      expect(logger).to have_received(:warn).with(/Failed to ensure labels/)
+    end
+  end
+end

--- a/spec/ocak/parallel_execution_spec.rb
+++ b/spec/ocak/parallel_execution_spec.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'ocak/parallel_execution'
+
+RSpec.describe Ocak::ParallelExecution do
+  let(:test_class) do
+    Class.new do
+      include Ocak::ParallelExecution
+
+      attr_accessor :run_single_step_impl
+
+      def initialize
+        @run_single_step_impl = nil
+      end
+
+      def symbolize(hash)
+        return hash unless hash.is_a?(Hash)
+
+        hash.transform_keys(&:to_sym)
+      end
+
+      def run_single_step(step, idx, issue_number, state, logger:, claude:, chdir:, mutex: nil) # rubocop:disable Metrics/ParameterLists
+        @run_single_step_impl&.call(step, idx, issue_number, state,
+                                    logger: logger, claude: claude, chdir: chdir, mutex: mutex)
+      end
+    end
+  end
+
+  let(:logger) { instance_double(Ocak::PipelineLogger, info: nil, warn: nil, error: nil, debug: nil) }
+  let(:claude) { instance_double(Ocak::ClaudeRunner) }
+  let(:success_result) { Ocak::ClaudeRunner::AgentResult.new(success: true, output: 'Done') }
+  let(:failure_result) { Ocak::ClaudeRunner::AgentResult.new(success: false, output: 'Error') }
+
+  let(:base_state) do
+    { completed_steps: [], steps_run: 0, total_cost: 0.0, step_results: {},
+      last_review_output: nil, had_fixes: false, audit_blocked: false }
+  end
+
+  subject(:instance) { test_class.new }
+
+  describe '#collect_parallel_group' do
+    it 'collects consecutive parallel steps starting at start_idx' do
+      steps = [
+        { 'agent' => 'reviewer', 'role' => 'review', 'parallel' => true },
+        { 'agent' => 'security-reviewer', 'role' => 'security', 'parallel' => true },
+        { 'agent' => 'merger', 'role' => 'merge' }
+      ]
+      group = instance.collect_parallel_group(steps, 0)
+      expect(group.size).to eq(2)
+      expect(group.map(&:last)).to eq([0, 1])
+    end
+
+    it 'stops at first non-parallel step' do
+      steps = [
+        { 'agent' => 'reviewer', 'role' => 'review', 'parallel' => true },
+        { 'agent' => 'merger', 'role' => 'merge' },
+        { 'agent' => 'auditor', 'role' => 'audit', 'parallel' => true }
+      ]
+      group = instance.collect_parallel_group(steps, 0)
+      expect(group.size).to eq(1)
+    end
+
+    it 'returns empty array when first step is not parallel' do
+      steps = [{ 'agent' => 'implementer', 'role' => 'implement' }]
+      group = instance.collect_parallel_group(steps, 0)
+      expect(group).to be_empty
+    end
+
+    it 'collects from non-zero start_idx' do
+      steps = [
+        { 'agent' => 'implementer', 'role' => 'implement' },
+        { 'agent' => 'reviewer', 'role' => 'review', 'parallel' => true },
+        { 'agent' => 'security-reviewer', 'role' => 'security', 'parallel' => true }
+      ]
+      group = instance.collect_parallel_group(steps, 1)
+      expect(group.size).to eq(2)
+      expect(group.map(&:last)).to eq([1, 2])
+    end
+
+    it 'returns empty array when start_idx is beyond steps size' do
+      steps = [{ 'agent' => 'implementer', 'role' => 'implement' }]
+      group = instance.collect_parallel_group(steps, 5)
+      expect(group).to be_empty
+    end
+
+    it 'symbolizes step hashes when collecting' do
+      steps = [{ 'agent' => 'reviewer', 'role' => 'review', 'parallel' => true }]
+      group = instance.collect_parallel_group(steps, 0)
+      step_hash = group.first.first
+      expect(step_hash[:parallel]).to be true
+    end
+  end
+
+  describe '#run_parallel_group' do
+    let(:step_a) { { agent: 'reviewer', role: 'review', parallel: true } }
+    let(:step_b) { { agent: 'security-reviewer', role: 'security', parallel: true } }
+    let(:group) { [[step_a, 0], [step_b, 1]] }
+
+    it 'runs all steps and returns nil when all succeed' do
+      instance.run_single_step_impl = ->(*_args, **_kwargs) {}
+      result = instance.run_parallel_group(group, 42, base_state, logger: logger, claude: claude,
+                                                                  chdir: '/project')
+      expect(result).to be_nil
+    end
+
+    it 'returns first failure result' do
+      failure_hash = { success: false, phase: 'security', output: 'Error' }
+      instance.run_single_step_impl = lambda do |step, *_args, **_kwargs|
+        step[:role] == 'security' ? failure_hash : nil
+      end
+
+      result = instance.run_parallel_group(group, 42, base_state, logger: logger, claude: claude,
+                                                                  chdir: '/project')
+      expect(result).to eq(failure_hash)
+    end
+
+    it 'runs steps in parallel (both steps called)' do
+      called_roles = []
+      mutex = Mutex.new
+      instance.run_single_step_impl = lambda do |step, *_args, **_kwargs|
+        mutex.synchronize { called_roles << step[:role] }
+        nil
+      end
+
+      instance.run_parallel_group(group, 42, base_state, logger: logger, claude: claude, chdir: '/project')
+      expect(called_roles).to contain_exactly('review', 'security')
+    end
+
+    it 'logs error when a thread raises StandardError' do
+      instance.run_single_step_impl = ->(*_args, **_kwargs) { raise StandardError, 'thread error' }
+      result = instance.run_parallel_group([[step_a, 0]], 42, base_state, logger: logger, claude: claude,
+                                                                          chdir: '/project')
+      expect(logger).to have_received(:error).with(/thread failed: thread error/)
+      expect(result).to be_nil
+    end
+
+    it 'passes a shared mutex to run_single_step' do
+      received_mutexes = []
+      instance.run_single_step_impl = lambda do |_step, _idx, _issue_number, _state,
+                                                  mutex: nil, **_|
+        received_mutexes << mutex
+        nil
+      end
+
+      instance.run_parallel_group(group, 42, base_state, logger: logger, claude: claude, chdir: '/project')
+      expect(received_mutexes.uniq.size).to eq(1)
+      expect(received_mutexes.first).to be_a(Mutex)
+    end
+  end
+end

--- a/spec/ocak/shutdown_handling_spec.rb
+++ b/spec/ocak/shutdown_handling_spec.rb
@@ -1,0 +1,166 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'ocak/shutdown_handling'
+require 'ocak/git_utils'
+
+RSpec.describe Ocak::ShutdownHandling do
+  let(:test_class) do
+    Class.new do
+      include Ocak::ShutdownHandling
+
+      public :shutdown!, :print_shutdown_summary, :handle_process_error, :handle_interrupted_issue
+
+      attr_reader :shutting_down, :shutdown_count, :interrupted_issues
+
+      def initialize(config:, registry:)
+        @config = config
+        @registry = registry
+        @shutting_down = false
+        @shutdown_count = 0
+        @active_mutex = Mutex.new
+        @interrupted_issues = []
+        @active_issues = []
+      end
+    end
+  end
+
+  let(:config) do
+    instance_double(Ocak::Config,
+                    label_in_progress: 'in-progress',
+                    label_failed: 'pipeline-failed',
+                    label_ready: 'auto-ready')
+  end
+  let(:registry) { instance_double(Ocak::ProcessRegistry, kill_all: nil) }
+  let(:logger) { instance_double(Ocak::PipelineLogger, info: nil, warn: nil, error: nil, debug: nil) }
+  let(:issues) { instance_double(Ocak::IssueFetcher, transition: nil, comment: nil) }
+
+  subject(:instance) { test_class.new(config: config, registry: registry) }
+
+  describe '#shutdown!' do
+    it 'initiates graceful shutdown on first call' do
+      instance.shutdown!
+      expect(instance.shutting_down).to be true
+    end
+
+    it 'calls kill_all on second call' do
+      instance.shutdown!
+      instance.shutdown!
+      expect(registry).to have_received(:kill_all)
+    end
+
+    it 'prints graceful message on first call' do
+      expect { instance.shutdown! }.to output(/Graceful shutdown/).to_stderr
+    end
+
+    it 'prints force message on second call' do
+      instance.shutdown!
+      expect { instance.shutdown! }.to output(/Force shutdown/).to_stderr
+    end
+
+    it 'sets shutting_down to true on force shutdown' do
+      instance.shutdown!
+      instance.shutdown!
+      expect(instance.shutting_down).to be true
+    end
+  end
+
+  describe '#print_shutdown_summary' do
+    it 'does nothing when no interrupted issues' do
+      expect { instance.print_shutdown_summary }.not_to output.to_stderr
+    end
+
+    it 'prints each interrupted issue with resume command' do
+      instance.instance_variable_set(:@interrupted_issues, [42, 99])
+      output = capture_stderr { instance.print_shutdown_summary }
+      expect(output).to include('Issue #42')
+      expect(output).to include('ocak resume --issue 42')
+      expect(output).to include('Issue #99')
+    end
+  end
+
+  describe '#handle_process_error' do
+    let(:error) { StandardError.new('something went wrong') }
+
+    before { error.set_backtrace(['line 1', 'line 2']) }
+
+    it 'logs error with class and message' do
+      instance.handle_process_error(error, issue_number: 42, logger: logger, issues: issues)
+      expect(logger).to have_received(:error).with(/Unexpected StandardError: something went wrong/)
+    end
+
+    it 'transitions issue to failed label' do
+      instance.handle_process_error(error, issue_number: 42, logger: logger, issues: issues)
+      expect(issues).to have_received(:transition)
+        .with(42, from: 'in-progress', to: 'pipeline-failed')
+    end
+
+    it 'posts error comment on issue' do
+      instance.handle_process_error(error, issue_number: 42, logger: logger, issues: issues)
+      expect(issues).to have_received(:comment).with(42, /Unexpected StandardError/)
+    end
+
+    it 'swallows comment posting errors' do
+      allow(issues).to receive(:comment).and_raise(StandardError, 'network error')
+      expect do
+        instance.handle_process_error(error, issue_number: 42, logger: logger, issues: issues)
+      end.not_to raise_error
+    end
+
+    it 'logs debug when comment posting fails' do
+      allow(issues).to receive(:comment).and_raise(StandardError, 'network error')
+      instance.handle_process_error(error, issue_number: 42, logger: logger, issues: issues)
+      expect(logger).to have_received(:debug).with(/Comment posting failed/)
+    end
+  end
+
+  describe '#handle_interrupted_issue' do
+    before do
+      allow(Ocak::GitUtils).to receive(:commit_changes)
+    end
+
+    it 'commits wip changes when worktree_path is provided' do
+      instance.handle_interrupted_issue(42, '/worktree', 'implement', logger: logger, issues: issues)
+      expect(Ocak::GitUtils).to have_received(:commit_changes)
+        .with(hash_including(chdir: '/worktree', message: /wip:.*42/))
+    end
+
+    it 'skips commit when worktree_path is nil' do
+      instance.handle_interrupted_issue(42, nil, 'implement', logger: logger, issues: issues)
+      expect(Ocak::GitUtils).not_to have_received(:commit_changes)
+    end
+
+    it 'transitions issue to ready label' do
+      instance.handle_interrupted_issue(42, nil, 'implement', logger: logger, issues: issues)
+      expect(issues).to have_received(:transition)
+        .with(42, from: 'in-progress', to: 'auto-ready')
+    end
+
+    it 'posts interrupted comment with resume command' do
+      instance.handle_interrupted_issue(42, nil, 'implement', logger: logger, issues: issues)
+      expect(issues).to have_received(:comment).with(42, /ocak resume --issue 42/)
+    end
+
+    it 'adds issue to interrupted_issues list' do
+      instance.handle_interrupted_issue(42, nil, 'implement', logger: logger, issues: issues)
+      expect(instance.interrupted_issues).to include(42)
+    end
+
+    it 'swallows StandardError and logs warning' do
+      allow(issues).to receive(:transition).and_raise(StandardError, 'API error')
+      expect do
+        instance.handle_interrupted_issue(42, nil, 'implement', logger: logger, issues: issues)
+      end.not_to raise_error
+      expect(logger).to have_received(:warn).with(/Failed to handle interrupted issue/)
+    end
+  end
+
+  def capture_stderr(&)
+    old_stderr = $stderr
+    $stderr = StringIO.new
+    yield
+    $stderr.string
+  ensure
+    $stderr = old_stderr
+  end
+end

--- a/spec/ocak/state_management_spec.rb
+++ b/spec/ocak/state_management_spec.rb
@@ -1,0 +1,309 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'tmpdir'
+require 'ocak/state_management'
+require 'ocak/run_report'
+
+RSpec.describe Ocak::StateManagement do
+  let(:test_class) do
+    Class.new do
+      include Ocak::StateManagement
+
+      public :accumulate_state, :save_step_progress, :write_step_output,
+             :check_step_failure, :check_cost_budget, :record_step_result,
+             :update_pipeline_state, :log_cost_summary, :save_report, :sync
+
+      def initialize(config:, logger:, pipeline_state:)
+        @config = config
+        @logger = logger
+        @pipeline_state_obj = pipeline_state
+      end
+
+      def pipeline_state = @pipeline_state_obj
+      def current_branch(_chdir, **) = 'main'
+      def post_step_completion_comment(_issue_number, _role, _result, **); end
+    end
+  end
+
+  let(:tmp_dir) { Dir.mktmpdir }
+  after { FileUtils.rm_rf(tmp_dir) }
+
+  let(:config) do
+    instance_double(Ocak::Config, project_dir: tmp_dir, cost_budget: nil)
+  end
+  let(:logger) { instance_double(Ocak::PipelineLogger, info: nil, warn: nil, error: nil, debug: nil) }
+  let(:pipeline_state_dbl) { instance_double(Ocak::PipelineState, save: nil) }
+  let(:run_report) { instance_double(Ocak::RunReport, record_step: nil, finish: nil, save: nil) }
+
+  subject(:instance) { test_class.new(config: config, logger: logger, pipeline_state: pipeline_state_dbl) }
+
+  let(:success_result) { Ocak::ClaudeRunner::AgentResult.new(success: true, output: 'Done', cost_usd: 0.05) }
+  let(:failure_result) { Ocak::ClaudeRunner::AgentResult.new(success: false, output: 'Error', cost_usd: 0.02) }
+
+  def make_state(overrides = {})
+    { completed_steps: [], steps_run: 0, steps_skipped: 0, total_cost: 0.0,
+      step_results: {}, last_review_output: nil, had_fixes: false,
+      audit_blocked: false, audit_output: nil, complexity: 'full',
+      interrupted: false, report: run_report }.merge(overrides)
+  end
+
+  def make_ctx(overrides = {})
+    state = overrides.delete(:state) || make_state
+    Ocak::StateManagement::StepContext.new(
+      overrides.fetch(:issue_number, 42),
+      overrides.fetch(:idx, 0),
+      overrides.fetch(:role, 'implement'),
+      overrides.fetch(:result, success_result),
+      state,
+      overrides.fetch(:logger, logger),
+      overrides.fetch(:chdir, '/project')
+    )
+  end
+
+  describe '#accumulate_state' do
+    it 'increments steps_run' do
+      ctx = make_ctx
+      instance.accumulate_state(ctx)
+      expect(ctx.state[:steps_run]).to eq(1)
+    end
+
+    it 'adds result cost to total_cost' do
+      ctx = make_ctx(result: success_result)
+      instance.accumulate_state(ctx)
+      expect(ctx.state[:total_cost]).to be_within(0.001).of(0.05)
+    end
+
+    it 'adds idx to completed_steps' do
+      ctx = make_ctx(idx: 3)
+      instance.accumulate_state(ctx)
+      expect(ctx.state[:completed_steps]).to include(3)
+    end
+
+    it 'stores result in step_results keyed by role' do
+      ctx = make_ctx(role: 'review', result: success_result)
+      instance.accumulate_state(ctx)
+      expect(ctx.state[:step_results]['review']).to eq(success_result)
+    end
+  end
+
+  describe '#update_pipeline_state' do
+    it 'sets last_review_output for review role' do
+      state = make_state
+      result = Ocak::ClaudeRunner::AgentResult.new(success: true, output: '🔴 finding')
+      instance.update_pipeline_state('review', result, state)
+      expect(state[:last_review_output]).to eq('🔴 finding')
+    end
+
+    it 'sets last_review_output for verify role' do
+      state = make_state
+      result = Ocak::ClaudeRunner::AgentResult.new(success: true, output: 'output')
+      instance.update_pipeline_state('verify', result, state)
+      expect(state[:last_review_output]).to eq('output')
+    end
+
+    it 'sets audit_output and audit_blocked when audit output contains 🔴' do
+      state = make_state
+      result = Ocak::ClaudeRunner::AgentResult.new(success: true, output: '🔴 security issue')
+      instance.update_pipeline_state('audit', result, state)
+      expect(state[:audit_blocked]).to be true
+      expect(state[:audit_output]).to eq('🔴 security issue')
+    end
+
+    it 'sets audit_blocked when audit result fails' do
+      state = make_state
+      result = Ocak::ClaudeRunner::AgentResult.new(success: false, output: 'error')
+      instance.update_pipeline_state('audit', result, state)
+      expect(state[:audit_blocked]).to be true
+    end
+
+    it 'does not set audit_blocked when audit passes with no findings' do
+      state = make_state
+      result = Ocak::ClaudeRunner::AgentResult.new(success: true, output: 'all clear')
+      instance.update_pipeline_state('audit', result, state)
+      expect(state[:audit_blocked]).to be false
+    end
+
+    it 'sets had_fixes for fix role' do
+      state = make_state
+      result = Ocak::ClaudeRunner::AgentResult.new(success: true, output: 'fixed')
+      instance.update_pipeline_state('fix', result, state)
+      expect(state[:had_fixes]).to be true
+    end
+
+    it 'clears last_review_output for fix role' do
+      state = make_state(last_review_output: 'some output')
+      result = Ocak::ClaudeRunner::AgentResult.new(success: true, output: 'fixed')
+      instance.update_pipeline_state('fix', result, state)
+      expect(state[:last_review_output]).to be_nil
+    end
+
+    it 'clears last_review_output for implement role' do
+      state = make_state(last_review_output: 'some output')
+      result = Ocak::ClaudeRunner::AgentResult.new(success: true, output: 'done')
+      instance.update_pipeline_state('implement', result, state)
+      expect(state[:last_review_output]).to be_nil
+    end
+  end
+
+  describe '#save_step_progress' do
+    it 'saves pipeline state with completed steps, path, and branch' do
+      ctx = make_ctx(idx: 1, chdir: '/worktree')
+      ctx.state[:completed_steps] << 1
+      instance.save_step_progress(ctx)
+      expect(pipeline_state_dbl).to have_received(:save)
+        .with(42, completed_steps: [1], worktree_path: '/worktree', branch: 'main')
+    end
+  end
+
+  describe '#write_step_output' do
+    it 'writes output to the correct file path' do
+      instance.write_step_output(42, 0, 'implement', 'some output')
+      path = File.join(tmp_dir, '.ocak', 'logs', 'issue-42', 'step-0-implement.md')
+      expect(File.read(path)).to eq('some output')
+    end
+
+    it 'does nothing when output is empty string' do
+      instance.write_step_output(42, 0, 'implement', '')
+      dir = File.join(tmp_dir, '.ocak', 'logs', 'issue-42')
+      expect(Dir.exist?(dir)).to be false
+    end
+
+    it 'does nothing when output is nil' do
+      expect { instance.write_step_output(42, 0, 'implement', nil) }.not_to raise_error
+    end
+
+    it 'skips write when issue_number is not all digits' do
+      instance.write_step_output('../../etc', 0, 'implement', 'output')
+      dir = File.join(tmp_dir, '.ocak', 'logs', 'issue-../../etc')
+      expect(Dir.exist?(dir)).to be false
+    end
+
+    it 'sanitizes agent name by removing non-alphanumeric characters' do
+      instance.write_step_output(42, 0, 'sec/../bad', 'output')
+      path = File.join(tmp_dir, '.ocak', 'logs', 'issue-42', 'step-0-secbad.md')
+      expect(File.exist?(path)).to be true
+    end
+
+    it 'logs debug when write fails' do
+      allow(FileUtils).to receive(:mkdir_p).and_raise(StandardError, 'permission denied')
+      instance.write_step_output(42, 0, 'implement', 'output')
+      expect(logger).to have_received(:debug).with(/Step output write failed/)
+    end
+  end
+
+  describe '#check_step_failure' do
+    it 'returns nil when step succeeds' do
+      ctx = make_ctx(role: 'implement', result: success_result)
+      expect(instance.check_step_failure(ctx)).to be_nil
+    end
+
+    it 'returns failure hash when implement step fails' do
+      ctx = make_ctx(role: 'implement', result: failure_result)
+      result = instance.check_step_failure(ctx)
+      expect(result).to eq({ success: false, phase: 'implement', output: 'Error' })
+    end
+
+    it 'returns failure hash when merge step fails' do
+      ctx = make_ctx(role: 'merge', result: failure_result)
+      result = instance.check_step_failure(ctx)
+      expect(result).to eq({ success: false, phase: 'merge', output: 'Error' })
+    end
+
+    it 'returns nil for non-critical step failure (review)' do
+      ctx = make_ctx(role: 'review', result: failure_result)
+      expect(instance.check_step_failure(ctx)).to be_nil
+    end
+
+    it 'logs error when critical step fails' do
+      ctx = make_ctx(role: 'implement', result: failure_result)
+      instance.check_step_failure(ctx)
+      expect(logger).to have_received(:error).with('implement failed')
+    end
+  end
+
+  describe '#check_cost_budget' do
+    it 'returns nil when no budget is configured' do
+      state = make_state(total_cost: 100.0)
+      expect(instance.check_cost_budget(state, logger)).to be_nil
+    end
+
+    it 'returns nil when cost is within budget' do
+      allow(config).to receive(:cost_budget).and_return(10.0)
+      state = make_state(total_cost: 5.0)
+      expect(instance.check_cost_budget(state, logger)).to be_nil
+    end
+
+    it 'returns failure hash when cost exceeds budget' do
+      allow(config).to receive(:cost_budget).and_return(1.0)
+      state = make_state(total_cost: 2.5)
+      result = instance.check_cost_budget(state, logger)
+      expect(result).to include(success: false, phase: 'budget')
+      expect(result[:output]).to include('$2.50')
+    end
+
+    it 'logs error when cost exceeds budget' do
+      allow(config).to receive(:cost_budget).and_return(1.0)
+      state = make_state(total_cost: 2.5)
+      instance.check_cost_budget(state, logger)
+      expect(logger).to have_received(:error).with(/Cost budget exceeded/)
+    end
+  end
+
+  describe '#log_cost_summary' do
+    it 'does nothing when cost is zero' do
+      instance.log_cost_summary(0.0, logger)
+      expect(logger).not_to have_received(:info)
+    end
+
+    it 'logs cost when non-zero' do
+      instance.log_cost_summary(0.1234, logger)
+      expect(logger).to have_received(:info).with(/Pipeline cost: \$0\.1234/)
+    end
+
+    it 'includes budget info when configured' do
+      allow(config).to receive(:cost_budget).and_return(5.0)
+      instance.log_cost_summary(1.5, logger)
+      expect(logger).to have_received(:info).with(/\$5\.00 budget/)
+    end
+  end
+
+  describe '#save_report' do
+    it 'calls finish and save on the report' do
+      instance.save_report(run_report, 42, success: true)
+      expect(run_report).to have_received(:finish).with(success: true, failed_phase: nil)
+      expect(run_report).to have_received(:save).with(42, project_dir: tmp_dir)
+    end
+
+    it 'passes failed_phase when provided' do
+      instance.save_report(run_report, 42, success: false, failed_phase: 'implement')
+      expect(run_report).to have_received(:finish).with(success: false, failed_phase: 'implement')
+    end
+
+    it 'swallows StandardError and logs debug' do
+      allow(run_report).to receive(:finish).and_raise(StandardError, 'disk full')
+      expect { instance.save_report(run_report, 42, success: true) }.not_to raise_error
+      expect(logger).to have_received(:debug).with(/Report save failed/)
+    end
+  end
+
+  describe '#sync' do
+    it 'yields without mutex when nil' do
+      called = false
+      instance.sync(nil) { called = true }
+      expect(called).to be true
+    end
+
+    it 'yields within mutex when provided' do
+      mutex = Mutex.new
+      called = false
+      instance.sync(mutex) { called = true }
+      expect(called).to be true
+    end
+
+    it 'returns the block value' do
+      result = instance.sync(nil) { 42 }
+      expect(result).to eq(42)
+    end
+  end
+end

--- a/spec/ocak/step_execution_spec.rb
+++ b/spec/ocak/step_execution_spec.rb
@@ -1,0 +1,247 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'ocak/step_execution'
+require 'ocak/state_management'
+
+RSpec.describe Ocak::StepExecution do
+  let(:test_class) do
+    Class.new do
+      include Ocak::StepExecution
+
+      public :run_single_step, :handle_already_completed, :record_skipped_step,
+             :execute_step, :skip_reason
+
+      def initialize(config:, skip_steps: [], skip_merge: false)
+        @config = config
+        @skip_steps = skip_steps
+        @skip_merge = skip_merge
+      end
+
+      def post_step_comment(issue_number, message, **); end
+      def build_step_prompt(_role, _issue_number, _review_output) = 'test prompt'
+      def record_step_result(*) = nil
+    end
+  end
+
+  let(:config) do
+    instance_double(Ocak::Config, audit_mode: false, manual_review: false)
+  end
+  let(:logger) { instance_double(Ocak::PipelineLogger, info: nil, warn: nil, error: nil, debug: nil) }
+  let(:claude) { instance_double(Ocak::ClaudeRunner) }
+  let(:success_result) { Ocak::ClaudeRunner::AgentResult.new(success: true, output: 'Done') }
+  let(:failure_result) { Ocak::ClaudeRunner::AgentResult.new(success: false, output: 'Error') }
+  let(:run_report) { instance_double(Ocak::RunReport, record_step: nil) }
+
+  let(:base_state) do
+    { completed_steps: [], steps_run: 0, steps_skipped: 0, total_cost: 0.0,
+      step_results: {}, last_review_output: nil, had_fixes: false,
+      audit_blocked: false, complexity: 'full', report: run_report }
+  end
+
+  subject(:instance) { test_class.new(config: config) }
+
+  describe '#handle_already_completed' do
+    it 'returns false when idx is not in skip_steps' do
+      expect(instance.handle_already_completed(0, 'implement', [], logger)).to be false
+    end
+
+    it 'returns true when idx is in skip_steps' do
+      expect(instance.handle_already_completed(0, 'implement', [0], logger)).to be true
+    end
+
+    it 'logs info message when step is already completed' do
+      instance.handle_already_completed(0, 'implement', [0], logger)
+      expect(logger).to have_received(:info).with('Skipping implement (already completed)')
+    end
+
+    it 'does not log when step is not skipped' do
+      instance.handle_already_completed(0, 'implement', [], logger)
+      expect(logger).not_to have_received(:info)
+    end
+  end
+
+  describe '#skip_reason' do
+    let(:step) { { role: 'implement', agent: 'implementer' } }
+
+    it 'returns nil when no skip condition applies' do
+      expect(instance.skip_reason(step, base_state)).to be_nil
+    end
+
+    it 'returns merge skip reason when skip_merge is true' do
+      host = test_class.new(config: config, skip_merge: true)
+      merge_step = { role: 'merge', agent: 'merger' }
+      expect(host.skip_reason(merge_step, base_state)).to eq('merge handled by MergeManager')
+    end
+
+    it 'returns audit blocking reason when audit_blocked is true' do
+      allow(config).to receive(:audit_mode).and_return(true)
+      merge_step = { role: 'merge', agent: 'merger' }
+      state = base_state.merge(audit_blocked: true)
+      expect(instance.skip_reason(merge_step, state)).to eq('audit found blocking issues')
+    end
+
+    it 'returns manual review reason when manual_review is true' do
+      allow(config).to receive(:manual_review).and_return(true)
+      merge_step = { role: 'merge', agent: 'merger' }
+      expect(instance.skip_reason(merge_step, base_state)).to eq('manual review mode')
+    end
+
+    it 'returns complexity reason for full step on simple issue' do
+      complex_step = { role: 'document', agent: 'documenter', complexity: 'full' }
+      state = base_state.merge(complexity: 'simple')
+      expect(instance.skip_reason(complex_step, state)).to eq('fast-track issue (simple complexity)')
+    end
+
+    it 'returns nil for full step on full complexity issue' do
+      complex_step = { role: 'document', agent: 'documenter', complexity: 'full' }
+      expect(instance.skip_reason(complex_step, base_state)).to be_nil
+    end
+
+    it 'returns has_findings reason when no blocking findings' do
+      findings_step = { role: 'fix', agent: 'implementer', condition: 'has_findings' }
+      state = base_state.merge(last_review_output: 'all good')
+      expect(instance.skip_reason(findings_step, state)).to eq('no blocking findings from review')
+    end
+
+    it 'returns has_findings reason when last_review_output is nil' do
+      findings_step = { role: 'fix', agent: 'implementer', condition: 'has_findings' }
+      expect(instance.skip_reason(findings_step, base_state)).to eq('no blocking findings from review')
+    end
+
+    it 'does not skip has_findings step when 🔴 findings are present' do
+      findings_step = { role: 'fix', agent: 'implementer', condition: 'has_findings' }
+      state = base_state.merge(last_review_output: '🔴 critical finding')
+      expect(instance.skip_reason(findings_step, state)).to be_nil
+    end
+
+    it 'returns had_fixes reason when no fixes were made' do
+      fixes_step = { role: 'verify', agent: 'verifier', condition: 'had_fixes' }
+      expect(instance.skip_reason(fixes_step, base_state)).to eq('no fixes were made')
+    end
+
+    it 'does not skip had_fixes step when fixes were made' do
+      fixes_step = { role: 'verify', agent: 'verifier', condition: 'had_fixes' }
+      state = base_state.merge(had_fixes: true)
+      expect(instance.skip_reason(fixes_step, state)).to be_nil
+    end
+  end
+
+  describe '#record_skipped_step' do
+    let(:state) { base_state.dup }
+
+    before { allow(instance).to receive(:post_step_comment) }
+
+    it 'increments steps_skipped' do
+      instance.record_skipped_step(42, state, 0, 'implementer', 'implement', 'no findings')
+      expect(state[:steps_skipped]).to eq(1)
+    end
+
+    it 'posts a skip comment' do
+      instance.record_skipped_step(42, state, 0, 'implementer', 'implement', 'no findings')
+      expect(instance).to have_received(:post_step_comment)
+        .with(42, '⏭️ **Skipping implement** — no findings')
+    end
+
+    it 'records step in report with skipped status' do
+      instance.record_skipped_step(42, state, 0, 'implementer', 'implement', 'no findings')
+      expect(run_report).to have_received(:record_step).with(
+        index: 0, agent: 'implementer', role: 'implement', status: 'skipped', skip_reason: 'no findings'
+      )
+    end
+  end
+
+  describe '#execute_step' do
+    let(:step) { { role: 'implement', agent: 'implementer' } }
+
+    before do
+      allow(claude).to receive(:run_agent).and_return(success_result)
+      allow(instance).to receive(:post_step_comment)
+    end
+
+    it 'calls claude.run_agent with agent and prompt' do
+      instance.execute_step(step, 42, nil, logger: logger, claude: claude, chdir: '/project')
+      expect(claude).to have_received(:run_agent).with('implementer', 'test prompt', chdir: '/project')
+    end
+
+    it 'returns the agent result' do
+      result = instance.execute_step(step, 42, nil, logger: logger, claude: claude, chdir: '/project')
+      expect(result).to eq(success_result)
+    end
+
+    it 'passes model override when step has model key' do
+      model_step = { role: 'implement', agent: 'implementer', model: 'sonnet' }
+      instance.execute_step(model_step, 42, nil, logger: logger, claude: claude, chdir: '/project')
+      expect(claude).to have_received(:run_agent)
+        .with('implementer', 'test prompt', chdir: '/project', model: 'sonnet')
+    end
+
+    it 'converts underscore agent names to hyphens' do
+      hyphen_step = { role: 'security', agent: 'security_reviewer' }
+      instance.execute_step(hyphen_step, 42, nil, logger: logger, claude: claude, chdir: '/project')
+      expect(claude).to have_received(:run_agent).with('security-reviewer', 'test prompt', chdir: '/project')
+    end
+
+    it 'posts in-progress step comment' do
+      instance.execute_step(step, 42, nil, logger: logger, claude: claude, chdir: '/project')
+      expect(instance).to have_received(:post_step_comment)
+        .with(42, '🔄 **Phase: implement** (implementer)')
+    end
+
+    it 'logs phase info' do
+      instance.execute_step(step, 42, nil, logger: logger, claude: claude, chdir: '/project')
+      expect(logger).to have_received(:info).with('--- Phase: implement (implementer) ---')
+    end
+  end
+
+  describe '#run_single_step' do
+    let(:step) { { role: 'implement', agent: 'implementer' } }
+    let(:state) { base_state.dup }
+
+    before do
+      allow(claude).to receive(:run_agent).and_return(success_result)
+      allow(instance).to receive(:post_step_comment)
+      allow(instance).to receive(:record_step_result)
+    end
+
+    it 'returns nil when step is already completed (in skip_steps)' do
+      host = test_class.new(config: config, skip_steps: [0])
+      result = host.run_single_step(step, 0, 42, state, logger: logger, claude: claude, chdir: '/project')
+      expect(result).to be_nil
+      expect(claude).not_to have_received(:run_agent)
+    end
+
+    it 'returns nil when step is skipped due to condition' do
+      findings_step = { role: 'fix', agent: 'implementer', condition: 'has_findings' }
+      result = instance.run_single_step(findings_step, 0, 42, state, logger: logger, claude: claude,
+                                                                     chdir: '/project')
+      expect(result).to be_nil
+      expect(claude).not_to have_received(:run_agent)
+    end
+
+    it 'logs skip reason info message' do
+      findings_step = { role: 'fix', agent: 'implementer', condition: 'has_findings' }
+      instance.run_single_step(findings_step, 0, 42, state, logger: logger, claude: claude, chdir: '/project')
+      expect(logger).to have_received(:info).with(/Skipping fix/)
+    end
+
+    it 'executes step and calls record_step_result' do
+      instance.run_single_step(step, 0, 42, state, logger: logger, claude: claude, chdir: '/project')
+      expect(instance).to have_received(:record_step_result)
+    end
+
+    it 'records step in report with completed status' do
+      instance.run_single_step(step, 0, 42, state, logger: logger, claude: claude, chdir: '/project')
+      expect(run_report).to have_received(:record_step).with(
+        index: 0, agent: 'implementer', role: 'implement', status: 'completed', result: success_result
+      )
+    end
+
+    it 'passes mutex to record_step_result' do
+      mutex = Mutex.new
+      instance.run_single_step(step, 0, 42, state, logger: logger, claude: claude, chdir: '/project',
+                                                   mutex: mutex)
+      expect(instance).to have_received(:record_step_result).with(anything, mutex: mutex)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Closes #191

- Added dedicated unit specs for 6 modules previously only tested indirectly
- Created test host classes following the pattern from `step_comments_spec.rb`
- All specs test public methods in isolation with mocked dependencies
- 1,355 lines of new test coverage

## Changes

- `spec/ocak/batch_processing_spec.rb` (282 lines) — tests `process_issues`, `run_batch`, `process_one_issue`, `build_issue_result`
- `spec/ocak/instance_builders_spec.rb` (200 lines) — tests `build_logger`, `build_claude`, `build_merge_manager`
- `spec/ocak/parallel_execution_spec.rb` (151 lines) — tests `collect_parallel_group`, `run_parallel_group`
- `spec/ocak/shutdown_handling_spec.rb` (166 lines) — tests `shutdown!`, `handle_interrupt`, `print_summary`
- `spec/ocak/state_management_spec.rb` (309 lines) — tests `accumulate_state`, `save_step_progress`, `write_step_output`, `check_step_failure`, `check_cost_budget`
- `spec/ocak/step_execution_spec.rb` (247 lines) — tests `run_single_step`, `execute_step`, `skip_reason`, `handle_already_completed`

## Testing

- `bundle exec rspec` — passed (all new specs + existing specs)
- `bundle exec rubocop -A` — passed