### PR TITLE
Release v0.5.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ocak (0.4.0)
+    ocak (0.5.0)
       dry-cli (~> 1.0)
 
 GEM
@@ -85,7 +85,7 @@ CHECKSUMS
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   mcp (0.7.1) sha256=fa967895d6952bad0d981ea907731d8528d2c246d2079d56a9c8bae83d14f1c7
-  ocak (0.4.0)
+  ocak (0.5.0)
   parallel (1.27.0) sha256=4ac151e1806b755fb4e2dc2332cbf0e54f2e24ba821ff2d3dcf86bf6dc4ae130
   parser (3.3.10.2) sha256=6f60c84aa4bdcedb6d1a2434b738fe8a8136807b6adc8f7f53b97da9bc4e9357
   prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85

--- a/README.md
+++ b/README.md
@@ -173,6 +173,19 @@ When `--manual-review` is enabled, PRs sit open for human review. After leaving 
 4. Remove the `auto-reready` label
 5. Comment "Feedback addressed. Please re-review."
 
+### Local Issues (Offline Mode)
+
+Ocak can run without GitHub. Set `issues.backend: local` in `ocak.yml` (or just create `.ocak/issues/` and it auto-detects). Issues are stored as numbered markdown files with YAML frontmatter.
+
+```bash
+ocak issue create "Add retry logic to API client" --label auto-ready
+ocak issue list
+ocak issue view 1
+ocak run 1 --watch
+```
+
+Issues live in `.ocak/issues/0001.md`, `.ocak/issues/0002.md`, etc. Labels, complexity, and pipeline comments are all tracked in the file. Merging goes straight to main (no PRs) via `LocalMergeManager`.
+
 ### Graceful Shutdown
 
 `Ctrl+C` once — current agent step finishes, then the pipeline stops. WIP gets committed, labels reset to `auto-ready`, and resume commands are printed.
@@ -198,6 +211,10 @@ stack:
   security_commands:
     - "bundle exec brakeman -q"
     - "bundle exec bundler-audit check"
+
+# Issue backend (omit for GitHub, or set to "local" for offline mode)
+issues:
+  backend: github          # or "local" — auto-detected if .ocak/issues/ exists
 
 # Pipeline settings
 pipeline:
@@ -397,6 +414,16 @@ ocak clean                           Remove stale worktrees
      --logs                         Clean log files, state, and reports
      --all                          Clean worktrees and logs
      --keep N                       Only remove artifacts older than N days
+
+ocak issue create TITLE [options]    Create a local issue
+     --body TEXT                     Issue body (opens $EDITOR if omitted)
+     --label LABEL                  Add label (repeatable)
+     --complexity full|simple       Set complexity (default: full)
+
+ocak issue list [--label LABEL]      List local issues
+ocak issue view ISSUE                View a local issue
+ocak issue edit ISSUE                Open issue in $EDITOR
+ocak issue close ISSUE               Mark issue as completed
 
 ocak design [DESCRIPTION]            Launch interactive issue design session
 ocak audit [SCOPE]                   Print instructions for /audit skill

--- a/lib/ocak.rb
+++ b/lib/ocak.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Ocak
-  VERSION = '0.4.0'
+  VERSION = '0.5.0'
 
   def self.root
     File.expand_path('..', __dir__)


### PR DESCRIPTION
## Summary

- Bump version from 0.4.0 to 0.5.0
- Document local issue store and `ocak issue` CLI commands in README
- Add `issues.backend` config example to README

## What's in 0.5.0

**New features:**
- Local issue store — file-based issue management for offline/non-GitHub use (`issues.backend: local`)
- `ocak issue create/list/view/edit/close` CLI commands
- Per-step model overrides in `ocak.yml`
- `CommandRunner` module for standardized git/gh command execution
- `ProjectKey` module to resolve owner/repo from git remote
- US Bedrock model IDs as defaults with env variable overrides

**Refactoring:**
- PipelineRunner extracted into 4 modules (batch_processing, instance_builders, shutdown_handling, merge_orchestration)
- PipelineExecutor extracted into 4 modules (parallel_execution, state_management, step_execution, step_comments)
- GitUtils, MergeManager, RereadyProcessor migrated to CommandRunner

**Bug fixes:**
- Parallel execution returns failure hash on thread exception instead of nil
- Verification checks git diff exit status in scoped lint
- RunReport handles SystemCallError in save and load_all
- WorktreeManager validates issue_number
- Broken logging in failure_reporting fixed
- Prompt injection protection for planner's external issue data

**Tests:**
- Dedicated unit specs for 6 core pipeline modules
- Unit specs for all 5 issue subcommands
- Specs for IssueBackend, LocalMergeManager, CommandRunner

**Improved agent templates** with battle-tested patterns from production use

## Test plan

- [x] `bundle exec rspec` — 1093 examples, 0 failures
- [ ] Tag v0.5.0 after merge
- [ ] `gem build && gem push`

🤖 Generated with [Claude Code](https://claude.com/claude-code)