### PR TITLE
feat(target_resolver): add TargetResolver module for multi-repo target parsing

### DIFF
--- a/lib/ocak/target_resolver.rb
+++ b/lib/ocak/target_resolver.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'yaml'
+
+module Ocak
+  module TargetResolver
+    # Resolves the target repo for an issue.
+    # Returns { name:, path: } hash or nil (single-repo mode).
+    # Raises TargetResolutionError on missing/invalid target in multi-repo mode.
+    def self.resolve(issue, config:)
+      return nil unless config.multi_repo?
+
+      body = issue['body'].to_s
+      repo_name = extract_target_name(body, field: config.target_field)
+
+      unless repo_name
+        raise TargetResolutionError,
+              "Issue ##{issue['number']} is missing required '#{config.target_field}' field in body. " \
+              "Known repos: #{config.repos.keys.join(', ')}"
+      end
+
+      config.resolve_repo(repo_name)
+    end
+
+    # Extract target name from YAML front-matter.
+    # Returns the target name string, or nil if not found.
+    def self.extract_target_name(body, field:)
+      match = body.match(/\A---\s*\n(.*?)\n---/m)
+      return nil unless match
+
+      frontmatter = YAML.safe_load(match[1])
+      return nil unless frontmatter.is_a?(Hash)
+
+      frontmatter[field]&.to_s&.strip
+    rescue Psych::SyntaxError
+      nil
+    end
+
+    class TargetResolutionError < StandardError; end
+  end
+end

--- a/spec/ocak/target_resolver_spec.rb
+++ b/spec/ocak/target_resolver_spec.rb
@@ -1,0 +1,190 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Ocak::TargetResolver do
+  # Use unverified double since multi_repo?, target_field, repos, resolve_repo
+  # are added by a dependency issue and not yet on Ocak::Config
+  let(:config) do
+    double(
+      'Config',
+      multi_repo?: true,
+      target_field: 'target_repo',
+      repos: { 'my-gem' => '/dev/my-gem', 'other-gem' => '/dev/other-gem' }
+    )
+  end
+
+  let(:issue) do
+    {
+      'number' => 42,
+      'body' => "---\ntarget_repo: my-gem\n---\n\n## Description\nUpdate the gem."
+    }
+  end
+
+  describe '.resolve' do
+    context 'when multi-repo is disabled' do
+      before { allow(config).to receive(:multi_repo?).and_return(false) }
+
+      it 'returns nil' do
+        expect(described_class.resolve(issue, config: config)).to be_nil
+      end
+    end
+
+    context 'when multi-repo is enabled' do
+      context 'with valid YAML front-matter containing the target field' do
+        before do
+          allow(config).to receive(:resolve_repo).with('my-gem').and_return({ name: 'my-gem', path: '/dev/my-gem' })
+        end
+
+        it 'returns a hash with name and path' do
+          result = described_class.resolve(issue, config: config)
+
+          expect(result).to eq({ name: 'my-gem', path: '/dev/my-gem' })
+        end
+
+        it 'delegates to config.resolve_repo with the extracted name' do
+          described_class.resolve(issue, config: config)
+
+          expect(config).to have_received(:resolve_repo).with('my-gem')
+        end
+      end
+
+      context 'when the issue body has no front-matter' do
+        let(:issue) { { 'number' => 42, 'body' => '## Description\nNo front-matter here.' } }
+
+        it 'raises TargetResolutionError' do
+          expect { described_class.resolve(issue, config: config) }
+            .to raise_error(Ocak::TargetResolver::TargetResolutionError, /missing required 'target_repo'/)
+        end
+
+        it 'includes the issue number in the error message' do
+          expect { described_class.resolve(issue, config: config) }
+            .to raise_error(Ocak::TargetResolver::TargetResolutionError, /Issue #42/)
+        end
+
+        it 'includes known repos in the error message' do
+          expect { described_class.resolve(issue, config: config) }
+            .to raise_error(Ocak::TargetResolver::TargetResolutionError, /my-gem/)
+        end
+      end
+
+      context 'when the front-matter is present but missing the target field' do
+        let(:issue) { { 'number' => 42, 'body' => "---\nother_field: value\n---\n\n## Description" } }
+
+        it 'raises TargetResolutionError' do
+          expect { described_class.resolve(issue, config: config) }
+            .to raise_error(Ocak::TargetResolver::TargetResolutionError, /missing required 'target_repo'/)
+        end
+      end
+
+      context 'when issue body is nil' do
+        let(:issue) { { 'number' => 42, 'body' => nil } }
+
+        it 'raises TargetResolutionError' do
+          expect { described_class.resolve(issue, config: config) }
+            .to raise_error(Ocak::TargetResolver::TargetResolutionError)
+        end
+      end
+
+      context 'when config.resolve_repo raises an error for unknown repo' do
+        before do
+          allow(config).to receive(:resolve_repo).with('unknown-gem')
+                                                 .and_raise(StandardError, 'Unknown repo: unknown-gem')
+        end
+
+        let(:issue) { { 'number' => 42, 'body' => "---\ntarget_repo: unknown-gem\n---" } }
+
+        it 'propagates the error from config.resolve_repo' do
+          expect { described_class.resolve(issue, config: config) }
+            .to raise_error(StandardError, /Unknown repo: unknown-gem/)
+        end
+      end
+    end
+  end
+
+  describe '.extract_target_name' do
+    context 'with valid front-matter containing the target field' do
+      it 'returns the target name string' do
+        body = "---\ntarget_repo: my-gem\n---\n\n## Description"
+
+        expect(described_class.extract_target_name(body, field: 'target_repo')).to eq('my-gem')
+      end
+    end
+
+    context 'with no front-matter' do
+      it 'returns nil' do
+        body = '## Description\nNo front-matter here.'
+
+        expect(described_class.extract_target_name(body, field: 'target_repo')).to be_nil
+      end
+    end
+
+    context 'with malformed YAML front-matter' do
+      it 'returns nil when Psych::SyntaxError is raised' do
+        body = "---\n: invalid: yaml: here\n---"
+
+        expect(described_class.extract_target_name(body, field: 'target_repo')).to be_nil
+      end
+    end
+
+    context 'when front-matter is not at the start of body' do
+      it 'returns nil' do
+        body = "Some text first\n---\ntarget_repo: my-gem\n---"
+
+        expect(described_class.extract_target_name(body, field: 'target_repo')).to be_nil
+      end
+    end
+
+    context 'with extra whitespace in the value' do
+      it 'strips whitespace from the name' do
+        body = "---\ntarget_repo:   my-gem   \n---"
+
+        expect(described_class.extract_target_name(body, field: 'target_repo')).to eq('my-gem')
+      end
+    end
+
+    context 'with front-matter containing extra fields' do
+      it 'extracts only the requested field' do
+        body = "---\nauthor: someone\ntarget_repo: my-gem\nversion: 1\n---"
+
+        expect(described_class.extract_target_name(body, field: 'target_repo')).to eq('my-gem')
+      end
+    end
+
+    context 'when body is empty' do
+      it 'returns nil' do
+        expect(described_class.extract_target_name('', field: 'target_repo')).to be_nil
+      end
+    end
+
+    context 'with only --- delimiters and no content' do
+      it 'returns nil' do
+        body = "---\n\n---"
+
+        expect(described_class.extract_target_name(body, field: 'target_repo')).to be_nil
+      end
+    end
+
+    context 'when front-matter value is numeric' do
+      it 'coerces the value to a string' do
+        body = "---\ntarget_repo: 123\n---"
+
+        expect(described_class.extract_target_name(body, field: 'target_repo')).to eq('123')
+      end
+    end
+
+    context 'when a different field name is specified' do
+      it 'extracts that field instead' do
+        body = "---\nrepo: other-gem\ntarget_repo: my-gem\n---"
+
+        expect(described_class.extract_target_name(body, field: 'repo')).to eq('other-gem')
+      end
+    end
+  end
+
+  describe 'TargetResolutionError' do
+    it 'is a subclass of StandardError' do
+      expect(described_class::TargetResolutionError.superclass).to eq(StandardError)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,6 +18,7 @@ require 'ocak/git_utils'
 require 'ocak/command_runner'
 require 'ocak/project_key'
 require 'ocak/reready_processor'
+require 'ocak/target_resolver'
 require 'ocak/logger'
 
 RSpec.configure do |config|


### PR DESCRIPTION
## Summary

Closes #216

- Adds `TargetResolver` module to parse YAML front-matter from GitHub issue bodies
- Extracts and validates target repo names using config's repo mapping
- Provides foundation for multi-repo pipeline feature

## Changes

- **lib/ocak/target_resolver.rb** — New module with `resolve()` and `extract_target_name()` methods
  - Parses YAML front-matter delimited by `---` at start of issue body
  - Returns `{ name:, path: }` hash when target found, `nil` in single-repo mode
  - Raises `TargetResolutionError` for missing/invalid targets in multi-repo mode
  - Uses `YAML.safe_load` for security
- **spec/ocak/target_resolver_spec.rb** — Comprehensive test coverage
  - Tests resolve logic with valid/missing/malformed front-matter
  - Tests extraction logic with edge cases (whitespace, malformed YAML, etc.)
  - Tests error handling for unknown repos
- **spec/spec_helper.rb** — Requires new module for test suite

## Testing

- `bundle exec rspec` — passed
- `bundle exec rubocop -A` — passed