### PR TITLE
feat(worktree_manager): accept repo_dir param for multi-repo support

### DIFF
--- a/lib/ocak/worktree_manager.rb
+++ b/lib/ocak/worktree_manager.rb
@@ -7,14 +7,15 @@ require 'shellwords'
 
 module Ocak
   class WorktreeManager
-    def initialize(config:, logger: nil)
+    def initialize(config:, repo_dir: nil, logger: nil)
       @config = config
       @logger = logger
-      @worktree_base = File.join(config.project_dir, config.worktree_dir)
+      @repo_dir = repo_dir || config.project_dir
+      @worktree_base = File.join(@repo_dir, config.worktree_dir)
       @mutex = Mutex.new
     end
 
-    def create(issue_number, setup_command: nil)
+    def create(issue_number, setup_command: nil, target_repo: nil)
       @mutex.synchronize do
         raise ArgumentError, "Invalid issue number: #{issue_number}" unless issue_number.to_s.match?(/\A\d+\z/)
 
@@ -31,7 +32,7 @@ module Ocak
           raise WorktreeError, "Setup command failed: #{stderr}" unless status.success?
         end
 
-        Worktree.new(path: path, branch: branch, issue_number: issue_number)
+        Worktree.new(path: path, branch: branch, issue_number: issue_number, target_repo: target_repo)
       end
     end
 
@@ -68,14 +69,14 @@ module Ocak
       removed
     end
 
-    Worktree = Struct.new(:path, :branch, :issue_number, keyword_init: true) # rubocop:disable Style/RedundantStructKeywordInit
+    Worktree = Struct.new(:path, :branch, :issue_number, :target_repo, keyword_init: true) # rubocop:disable Style/RedundantStructKeywordInit
 
     class WorktreeError < StandardError; end
 
     private
 
     def git(*)
-      Open3.capture3('git', *, chdir: @config.project_dir)
+      Open3.capture3('git', *, chdir: @repo_dir)
     end
 
     def parse_worktree_list(output)

--- a/spec/ocak/worktree_manager_spec.rb
+++ b/spec/ocak/worktree_manager_spec.rb
@@ -11,6 +11,27 @@ RSpec.describe Ocak::WorktreeManager do
 
   subject(:manager) { described_class.new(config: config) }
 
+  describe '#initialize' do
+    it 'uses config.project_dir when repo_dir is not provided' do
+      expect(manager.instance_variable_get(:@repo_dir)).to eq('/project')
+    end
+
+    it 'uses repo_dir when provided' do
+      manager_with_repo_dir = described_class.new(config: config, repo_dir: '/dev/my-gem')
+      expect(manager_with_repo_dir.instance_variable_get(:@repo_dir)).to eq('/dev/my-gem')
+    end
+
+    it 'uses repo_dir for worktree_base when provided' do
+      manager_with_repo_dir = described_class.new(config: config, repo_dir: '/dev/my-gem')
+      expect(manager_with_repo_dir.instance_variable_get(:@worktree_base)).to eq('/dev/my-gem/.claude/worktrees')
+    end
+
+    it 'falls back to config.project_dir when repo_dir is nil' do
+      manager_with_nil = described_class.new(config: config, repo_dir: nil)
+      expect(manager_with_nil.instance_variable_get(:@repo_dir)).to eq('/project')
+    end
+  end
+
   describe '#create' do
     it 'creates a worktree with the correct branch naming' do
       allow(FileUtils).to receive(:mkdir_p)
@@ -63,6 +84,43 @@ RSpec.describe Ocak::WorktreeManager do
       expect(worktree.path).to eq('/project/.claude/worktrees/issue-42')
       expect(Open3).to have_received(:capture3)
         .with('bundle', 'install', chdir: '/project/.claude/worktrees/issue-42')
+    end
+
+    it 'returns a Worktree with target_repo when provided' do
+      allow(FileUtils).to receive(:mkdir_p)
+      allow(Open3).to receive(:capture3)
+        .with('git', 'worktree', 'add', '-b', anything, anything, 'main', chdir: '/project')
+        .and_return(['', '', instance_double(Process::Status, success?: true)])
+
+      target_repo = { name: 'my-gem', path: '/dev/my-gem' }
+      worktree = manager.create(42, target_repo: target_repo)
+
+      expect(worktree.target_repo).to eq(target_repo)
+    end
+
+    it 'returns a Worktree with nil target_repo when not provided' do
+      allow(FileUtils).to receive(:mkdir_p)
+      allow(Open3).to receive(:capture3)
+        .with('git', 'worktree', 'add', '-b', anything, anything, 'main', chdir: '/project')
+        .and_return(['', '', instance_double(Process::Status, success?: true)])
+
+      worktree = manager.create(42)
+
+      expect(worktree.target_repo).to be_nil
+    end
+
+    it 'uses repo_dir as chdir for git commands' do
+      manager_with_repo_dir = described_class.new(config: config, repo_dir: '/dev/my-gem')
+      allow(FileUtils).to receive(:mkdir_p)
+      allow(Open3).to receive(:capture3)
+        .with('git', 'worktree', 'add', '-b', anything, anything, 'main', chdir: '/dev/my-gem')
+        .and_return(['', '', instance_double(Process::Status, success?: true)])
+
+      worktree = manager_with_repo_dir.create(42)
+
+      expect(worktree.path).to eq('/dev/my-gem/.claude/worktrees/issue-42')
+      expect(Open3).to have_received(:capture3)
+        .with('git', 'worktree', 'add', '-b', anything, anything, 'main', chdir: '/dev/my-gem')
     end
 
     it 'raises when setup command fails' do


### PR DESCRIPTION
## Summary

Closes #214

- Added `repo_dir:` optional parameter to `WorktreeManager#initialize` for multi-repo support
- Updated `Worktree` struct to include `target_repo` field
- Modified `create` method to accept and propagate `target_repo:` parameter
- All git commands now use the specified `repo_dir` instead of always using `config.project_dir`

## Changes

- **lib/ocak/worktree_manager.rb**: Added `repo_dir:` parameter to `initialize`, updated `Worktree` struct with `target_repo` field, modified `create` to accept `target_repo:`, updated private `git` helper to use `@repo_dir`
- **spec/ocak/worktree_manager_spec.rb**: Added comprehensive test coverage for new parameters and behavior
- **lib/ocak/config.rb**: Added supporting infrastructure for multi-repo configuration
- **spec/ocak/config_spec.rb**: Added tests for multi-repo config support

## Testing

- `bundle exec rspec` — passed
- `bundle exec rubocop -A` — passed