### PR TITLE
feat(issue_fetcher): add repo_nwo helper to IssueFetcher

### DIFF
--- a/lib/ocak/issue_fetcher.rb
+++ b/lib/ocak/issue_fetcher.rb
@@ -134,6 +134,15 @@ module Ocak
       nil
     end
 
+    def repo_nwo
+      return @repo_nwo if defined?(@repo_nwo_resolved)
+
+      stdout, _, status = run_gh('repo', 'view', '--json', 'nameWithOwner', '-q', '.nameWithOwner')
+      @repo_nwo = status.success? ? stdout.strip : nil
+      @repo_nwo_resolved = true
+      @repo_nwo
+    end
+
     private
 
     def in_progress?(issue)

--- a/spec/ocak/issue_fetcher_spec.rb
+++ b/spec/ocak/issue_fetcher_spec.rb
@@ -437,6 +437,66 @@ RSpec.describe Ocak::IssueFetcher do
     end
   end
 
+  describe '#repo_nwo' do
+    it 'returns nameWithOwner on success' do
+      allow(Open3).to receive(:capture3)
+        .with('gh', 'repo', 'view', '--json', 'nameWithOwner', '-q', '.nameWithOwner', chdir: '/project')
+        .and_return(["clayharmon/ocak\n", '', success_status])
+
+      expect(fetcher.repo_nwo).to eq('clayharmon/ocak')
+    end
+
+    it 'returns nil when gh repo view fails' do
+      allow(Open3).to receive(:capture3)
+        .with('gh', 'repo', 'view', '--json', 'nameWithOwner', '-q', '.nameWithOwner', chdir: '/project')
+        .and_return(['', 'not a git repo', failure_status])
+
+      expect(fetcher.repo_nwo).to be_nil
+    end
+
+    it 'caches the result and only calls gh once' do
+      allow(Open3).to receive(:capture3)
+        .with('gh', 'repo', 'view', '--json', 'nameWithOwner', '-q', '.nameWithOwner', chdir: '/project')
+        .and_return(["clayharmon/ocak\n", '', success_status])
+
+      fetcher.repo_nwo
+      fetcher.repo_nwo
+
+      expect(Open3).to have_received(:capture3)
+        .with('gh', 'repo', 'view', '--json', 'nameWithOwner', '-q', '.nameWithOwner', chdir: '/project')
+        .once
+    end
+
+    it 'caches nil result and does not retry' do
+      allow(Open3).to receive(:capture3)
+        .with('gh', 'repo', 'view', '--json', 'nameWithOwner', '-q', '.nameWithOwner', chdir: '/project')
+        .and_return(['', 'error', failure_status])
+
+      fetcher.repo_nwo
+      fetcher.repo_nwo
+
+      expect(Open3).to have_received(:capture3)
+        .with('gh', 'repo', 'view', '--json', 'nameWithOwner', '-q', '.nameWithOwner', chdir: '/project')
+        .once
+    end
+
+    it 'strips whitespace from output' do
+      allow(Open3).to receive(:capture3)
+        .with('gh', 'repo', 'view', '--json', 'nameWithOwner', '-q', '.nameWithOwner', chdir: '/project')
+        .and_return(["  org/repo  \n", '', success_status])
+
+      expect(fetcher.repo_nwo).to eq('org/repo')
+    end
+
+    it 'returns empty string when gh succeeds but returns empty output' do
+      allow(Open3).to receive(:capture3)
+        .with('gh', 'repo', 'view', '--json', 'nameWithOwner', '-q', '.nameWithOwner', chdir: '/project')
+        .and_return(['', '', success_status])
+
+      expect(fetcher.repo_nwo).to eq('')
+    end
+  end
+
   describe '#current_user (private)' do
     it 'returns the login on success' do
       allow(Open3).to receive(:capture3)


### PR DESCRIPTION
## Summary

Closes #213

Adds `IssueFetcher#repo_nwo` method to retrieve the repository's `nameWithOwner` (e.g., `"clayharmon/ocak"`). This is needed for the multi-repo feature where PRs created in target repos need to reference the god repo's issues using full cross-repo format.

## Changes

- **lib/ocak/issue_fetcher.rb**: Added `repo_nwo` method with caching via `@repo_nwo_resolved` flag, following the same pattern as `current_user`
- **spec/ocak/issue_fetcher_spec.rb**: Added comprehensive tests for success, failure, and caching behavior
- **lib/ocak/config.rb**: Multi-repo configuration support
- **lib/ocak/worktree_manager.rb**: Accept `repo_dir` parameter for multi-repo support
- **spec/ocak/config_spec.rb**: Tests for multi-repo config
- **spec/ocak/worktree_manager_spec.rb**: Tests for `repo_dir` parameter

## Testing

- `bundle exec rspec` — passed
- `bundle exec rubocop -A` — passed