### PR TITLE
feat(merge_orchestration): thread target_repo chdir for multi-repo support

### DIFF
--- a/lib/ocak/merge_orchestration.rb
+++ b/lib/ocak/merge_orchestration.rb
@@ -23,24 +23,32 @@ module Ocak
     end
 
     def handle_single_success(issue_number, result, logger:, claude:, issues:)
+      target_dir = result[:target_repo]&.dig(:path) || @config.project_dir
+
       if result[:audit_blocked]
-        handle_single_audit_blocked(issue_number, result, logger: logger, claude: claude, issues: issues)
+        handle_single_audit_blocked(issue_number, result, logger: logger, claude: claude, issues: issues,
+                                                          chdir: target_dir)
       elsif @config.manual_review
-        handle_single_manual_review(issue_number, logger: logger, claude: claude, issues: issues)
+        handle_single_manual_review(issue_number, logger: logger, claude: claude, issues: issues, chdir: target_dir)
       else
         unless pipeline_has_merge_step?
-          claude.run_agent('merger', "Create a PR, merge it, and close issue ##{issue_number}",
-                           chdir: @config.project_dir)
+          prompt = if result[:target_repo]
+                     "Create a PR and merge it for issue ##{issue_number}. " \
+                       'Do NOT close any issues (the issue lives in a different repository).'
+                   else
+                     "Create a PR, merge it, and close issue ##{issue_number}"
+                   end
+          claude.run_agent('merger', prompt, chdir: target_dir)
         end
         issues.transition(issue_number, from: @config.label_in_progress, to: @config.label_completed)
         logger.info("Issue ##{issue_number} completed successfully")
       end
     end
 
-    def handle_single_manual_review(issue_number, logger:, claude:, issues:)
+    def handle_single_manual_review(issue_number, logger:, claude:, issues:, chdir: @config.project_dir)
       claude.run_agent('merger',
                        "Create a PR for issue ##{issue_number} but do NOT merge it and do NOT close the issue",
-                       chdir: @config.project_dir)
+                       chdir: chdir)
       issues.transition(issue_number, from: @config.label_in_progress, to: @config.label_awaiting_review)
       logger.info("Issue ##{issue_number} PR created (manual review mode)")
     end
@@ -57,9 +65,9 @@ module Ocak
       end
     end
 
-    def handle_single_audit_blocked(issue_number, result, logger:, claude:, issues:)
-      handle_single_manual_review(issue_number, logger: logger, claude: claude, issues: issues)
-      post_audit_comment_single(result[:audit_output], logger: logger, issues: issues)
+    def handle_single_audit_blocked(issue_number, result, logger:, claude:, issues:, chdir: @config.project_dir)
+      handle_single_manual_review(issue_number, logger: logger, claude: claude, issues: issues, chdir: chdir)
+      post_audit_comment_single(result[:audit_output], logger: logger, issues: issues, chdir: chdir)
     end
 
     def handle_batch_audit(result, merger:, issues:, logger:)
@@ -79,8 +87,8 @@ module Ocak
       end
     end
 
-    def post_audit_comment_single(audit_output, logger:, issues:)
-      pr_number = find_pr_for_branch(logger: logger)
+    def post_audit_comment_single(audit_output, logger:, issues:, chdir: @config.project_dir)
+      pr_number = find_pr_for_branch(logger: logger, chdir: chdir)
       unless pr_number
         logger.warn("Could not find PR to post audit comment — findings were: #{audit_output.to_s[0..200]}")
         return
@@ -94,8 +102,8 @@ module Ocak
       @config.steps.any? { |s| s[:role].to_s == 'merge' || s['role'].to_s == 'merge' }
     end
 
-    def find_pr_for_branch(logger:)
-      stdout, _, status = Open3.capture3('gh', 'pr', 'view', '--json', 'number', chdir: @config.project_dir)
+    def find_pr_for_branch(logger:, chdir: @config.project_dir)
+      stdout, _, status = Open3.capture3('gh', 'pr', 'view', '--json', 'number', chdir: chdir)
       return nil unless status.success?
 
       data = JSON.parse(stdout)

--- a/spec/ocak/merge_orchestration_spec.rb
+++ b/spec/ocak/merge_orchestration_spec.rb
@@ -165,6 +165,65 @@ RSpec.describe Ocak::MergeOrchestration do
         expect(claude).not_to have_received(:run_agent)
       end
     end
+
+    context 'when result includes target_repo' do
+      let(:target_repo) { { name: 'my-gem', path: '/dev/my-gem' } }
+
+      it 'runs merger agent with target repo chdir' do
+        allow(claude).to receive(:run_agent).and_return(success_result)
+
+        host.handle_single_success(42, { success: true, target_repo: target_repo },
+                                   logger: logger, claude: claude, issues: issues)
+
+        expect(claude).to have_received(:run_agent)
+          .with('merger', /Do NOT close any issues/, chdir: '/dev/my-gem')
+      end
+
+      it 'still transitions to completed' do
+        allow(claude).to receive(:run_agent).and_return(success_result)
+
+        host.handle_single_success(42, { success: true, target_repo: target_repo },
+                                   logger: logger, claude: claude, issues: issues)
+
+        expect(issues).to have_received(:transition).with(42, from: 'in-progress', to: 'completed')
+      end
+
+      it 'passes target chdir to manual review when manual_review enabled' do
+        allow(config).to receive(:manual_review).and_return(true)
+        allow(claude).to receive(:run_agent).and_return(success_result)
+
+        host.handle_single_success(42, { success: true, target_repo: target_repo },
+                                   logger: logger, claude: claude, issues: issues)
+
+        expect(claude).to have_received(:run_agent)
+          .with('merger', anything, chdir: '/dev/my-gem')
+      end
+
+      it 'passes target chdir through audit blocked handler' do
+        allow(claude).to receive(:run_agent).and_return(success_result)
+        allow(Open3).to receive(:capture3)
+          .with('gh', 'pr', 'view', '--json', 'number', chdir: '/dev/my-gem')
+          .and_return(['{"number":77}', '', instance_double(Process::Status, success?: true)])
+
+        host.handle_single_success(42, { success: true, audit_blocked: true, audit_output: 'findings',
+                                         target_repo: target_repo },
+                                   logger: logger, claude: claude, issues: issues)
+
+        expect(issues).to have_received(:pr_comment).with(77, /Audit Report/)
+      end
+    end
+
+    context 'when target_repo has no path (edge case)' do
+      it 'falls back to project_dir' do
+        allow(claude).to receive(:run_agent).and_return(success_result)
+
+        host.handle_single_success(42, { success: true, target_repo: {} },
+                                   logger: logger, claude: claude, issues: issues)
+
+        expect(claude).to have_received(:run_agent)
+          .with('merger', anything, chdir: '/project')
+      end
+    end
   end
 
   describe '#pipeline_has_merge_step?' do
@@ -186,6 +245,27 @@ RSpec.describe Ocak::MergeOrchestration do
       it 'returns true' do
         expect(host.pipeline_has_merge_step?).to be true
       end
+    end
+  end
+
+  describe '#handle_single_manual_review' do
+    it 'uses project_dir by default' do
+      allow(claude).to receive(:run_agent).and_return(success_result)
+
+      host.handle_single_manual_review(42, logger: logger, claude: claude, issues: issues)
+
+      expect(claude).to have_received(:run_agent)
+        .with('merger', anything, chdir: '/project')
+    end
+
+    it 'uses explicit chdir param when provided' do
+      allow(claude).to receive(:run_agent).and_return(success_result)
+
+      host.handle_single_manual_review(42, logger: logger, claude: claude, issues: issues,
+                                           chdir: '/custom/path')
+
+      expect(claude).to have_received(:run_agent)
+        .with('merger', anything, chdir: '/custom/path')
     end
   end
 
@@ -277,6 +357,14 @@ RSpec.describe Ocak::MergeOrchestration do
 
       expect(host.find_pr_for_branch(logger: logger)).to be_nil
       expect(logger).to have_received(:warn).with(/Failed to find PR number/)
+    end
+
+    it 'uses explicit chdir param when provided' do
+      allow(Open3).to receive(:capture3)
+        .with('gh', 'pr', 'view', '--json', 'number', chdir: '/target/repo')
+        .and_return(['{"number":42}', '', instance_double(Process::Status, success?: true)])
+
+      expect(host.find_pr_for_branch(logger: logger, chdir: '/target/repo')).to eq(42)
     end
   end
 end


### PR DESCRIPTION
## Summary

Closes #209

- Enables `MergeOrchestration` to run merger agent and PR lookups in the correct target repository directory in multi-repo mode
- Threads `chdir:` parameter through `handle_single_success`, `handle_single_manual_review`, `find_pr_for_branch`, and `handle_single_audit_blocked`
- Adds "Do NOT close any issues" instruction to merger prompt when target_repo is present (issue lives in a different repo)
- Maintains full backwards compatibility for single-repo mode

## Changes

**Core Implementation:**
- `lib/ocak/merge_orchestration.rb` — threaded `chdir` param through all merge methods; extracts target directory from `result[:target_repo][:path]`; modified merger prompt for cross-repo scenarios
- `lib/ocak/merge_manager.rb` — added multi-repo PR body format with cross-repo issue linking
- `lib/ocak/batch_processing.rb` — enhanced target repo resolution with frontmatter parsing and config validation
- `lib/ocak/config.rb` — added `multi_repo?`, `resolve_repo`, and `repos` config support
- `lib/ocak/worktree_manager.rb` — added `target_repo` field to Worktree struct; threaded through create/remove
- `lib/ocak/issue_fetcher.rb` — added `repo_nwo` helper for extracting owner/name from origin URL

**Tests:**
- `spec/ocak/merge_orchestration_spec.rb` — 88 new lines covering multi-repo chdir paths and merger prompt variations
- `spec/ocak/merge_manager_spec.rb` — 191 new lines covering cross-repo PR creation scenarios
- `spec/ocak/batch_processing_spec.rb` — 180 new lines covering target resolution from frontmatter
- `spec/ocak/config_spec.rb` — 90 new lines covering multi_repo config validation and repo resolution
- `spec/ocak/worktree_manager_spec.rb` — 58 new lines covering target_repo threading
- `spec/ocak/issue_fetcher_spec.rb` — 60 new lines covering repo_nwo helper

**Documentation:**
- `CLAUDE.md` — updated architecture docs to reflect target resolution, multi-repo batch processing patterns

## Testing

- `bundle exec rspec` — passed (all existing + new tests)
- `bundle exec rubocop -A` — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)