### PR TITLE
feat(templates): add multi-repo awareness to agent templates and docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,47 @@ All externally-sourced content embedded in agent prompts must be wrapped in XML 
 - `ProcessRegistry` is a thread-safe PID set (`Mutex` + `Set`). `ProcessRunner#run` registers PIDs after `popen3` spawn and unregisters in `ensure`. `ClaudeRunner` passes the registry through to `ProcessRunner`.
 - `PipelineExecutor` accepts a `shutdown_check:` callable and checks it between steps; if true, it sets `state[:interrupted]` and breaks out of the step loop without deleting `PipelineState`.
 
+## Multi-Repo Mode
+
+In multi-repo mode a "god repo" holds all the issues while agents run in separate target repos. This lets one Ocak instance manage work across many codebases.
+
+### Overview
+- Issues live in the god repo. Each issue specifies its target via YAML front-matter.
+- Agents run in worktrees of the target repo, not the god repo.
+- Labels and comments are posted back to the god repo's issue tracker.
+- PRs are created and merged in the target repo.
+
+### Issue Format
+Issues include a YAML front-matter block identifying the target repo:
+```
+---
+target_repo: my-service
+---
+```
+
+### User Config
+Repo name-to-path mappings live in `~/.config/ocak/config.yml` (machine-specific, never committed):
+```yaml
+repos:
+  my-service: /path/to/my-service
+  another-repo: /path/to/another-repo
+```
+
+### Flow
+1. `TargetResolver` parses the issue body front-matter to extract the `target_repo` name.
+2. `Config#resolve_repo` looks up the name in `repos:` from user config and returns the local path. Raises `TargetResolutionError` if the name is unknown.
+3. `BatchProcessing#resolve_targets` calls `TargetResolver` for each issue in the batch.
+4. `WorktreeManager` creates a worktree in the target repo directory (via `repo_dir:` param).
+5. Pipeline agents run with `chdir: worktree.path`, so all file operations and git commands apply to the target repo.
+6. `MergeManager` rebases, pushes, and creates the PR in the target repo.
+7. Issue labels and comments are posted to the god repo via `IssueFetcher`.
+
+### Key Files
+- `target_resolver.rb` — parses front-matter, validates repo name via `Config#resolve_repo`
+- `batch_processing.rb` — `resolve_targets` maps issues to target repo paths
+- `worktree_manager.rb` — accepts `repo_dir:` param for target repo path
+- `merge_manager.rb` — includes target repo context in PR body
+
 ## Development
 
 ```bash

--- a/lib/ocak/templates/agents/implementer.md.erb
+++ b/lib/ocak/templates/agents/implementer.md.erb
@@ -98,6 +98,9 @@ You implement GitHub issues. The issue is your single source of truth — everyt
 <%- end -%>
 <%- end -%>
 
+### Working Directory Context
+If a CLAUDE.md file exists in the current working directory, read it for project-specific conventions, patterns, and architecture. This is especially important when working in a repository you haven't seen before.
+
 ### General Rules
 
 - Do NOT add features, refactoring, or improvements beyond what the issue specifies

--- a/lib/ocak/templates/agents/merger.md.erb
+++ b/lib/ocak/templates/agents/merger.md.erb
@@ -24,6 +24,15 @@ Only re-run tests if you had to resolve merge conflicts or edit files:
 <%- if lint_command -%>
 <%= lint_command %>
 <%- end -%>
+<%- unless test_command || lint_command -%>
+# No specific test/lint commands configured. Detect from project structure:
+# - Gemfile → bundle exec rspec (or bundle exec rake test)
+# - package.json → npm test
+# - Cargo.toml → cargo test
+# - go.mod → go test ./...
+# - pyproject.toml / setup.py → pytest
+# Read the project's CLAUDE.md for additional conventions.
+<%- end -%>
 ```
 
 If anything fails after conflict resolution, STOP and report the failures. Do not create a PR with failing checks.
@@ -62,6 +71,9 @@ Closes #<issue-number>
 <%- end -%>
 <%- if lint_command -%>
 - `<%= lint_command %>` — passed
+<%- end -%>
+<%- unless test_command || lint_command -%>
+- Stack auto-detected from project structure; commands detected at runtime
 <%- end -%>
 EOF
 )"

--- a/lib/ocak/templates/agents/pipeline.md.erb
+++ b/lib/ocak/templates/agents/pipeline.md.erb
@@ -33,6 +33,15 @@ gh issue view <number> --json title,body,labels
 <%- if test_command -%>
    - `<%= test_command %>`
 <%- end -%>
+<%- unless lint_command || test_command -%>
+   - No specific commands configured. Detect from project structure:
+     - Gemfile → bundle exec rspec (or bundle exec rake test)
+     - package.json → npm test
+     - Cargo.toml → cargo test
+     - go.mod → go test ./...
+     - pyproject.toml / setup.py → pytest
+   - Read the project's CLAUDE.md for additional conventions.
+<%- end -%>
 
 ### Phase 2: Self-Review
 
@@ -87,6 +96,15 @@ Run the complete check suite one last time:
 <%- end -%>
 <%- if test_command -%>
 <%= test_command %>
+<%- end -%>
+<%- unless lint_command || test_command -%>
+# No specific commands configured. Detect from project structure:
+# - Gemfile → bundle exec rspec (or bundle exec rake test)
+# - package.json → npm test
+# - Cargo.toml → cargo test
+# - go.mod → go test ./...
+# - pyproject.toml / setup.py → pytest
+# Read the project's CLAUDE.md for additional conventions.
 <%- end -%>
 ```
 

--- a/lib/ocak/templates/ocak.yml.erb
+++ b/lib/ocak/templates/ocak.yml.erb
@@ -27,6 +27,11 @@ stack:
 <%- end -%>
 <%- end -%>
 
+# Multi-repo mode — process issues across multiple local repos
+# Repo path mappings go in ~/.config/ocak/config.yml (machine-specific, not committed)
+# multi_repo: true
+# target_field: target_repo   # YAML front-matter field in issue body
+
 # Issue backend — 'github' (default) or 'local'
 # Local mode stores issues as files in .ocak/issues/ (no gh CLI needed for issues).
 # Auto-detected: if .ocak/issues/ contains .md files, local mode is used automatically.


### PR DESCRIPTION
## Summary

Closes #226

This PR enhances agent templates and documentation to support multi-repo mode where a "god repo" holds issues while agents run in different target repos with potentially different tech stacks.

- Agent templates now include fallback stack detection when no specific commands are configured
- Implementer agent now reads target repo's CLAUDE.md for project-specific conventions
- ocak.yml template includes commented multi-repo configuration example
- CLAUDE.md now documents the complete multi-repo architecture

## Changes

- **CLAUDE.md**: Added "Multi-Repo Mode" section documenting the full architecture (TargetResolver, YAML front-matter, user config, workflow)
- **lib/ocak/templates/agents/merger.md.erb**: Added fallback stack detection when `test_command` and `lint_command` are nil
- **lib/ocak/templates/agents/pipeline.md.erb**: Added fallback stack detection in both Phase 1 and Phase 5 verification steps
- **lib/ocak/templates/agents/implementer.md.erb**: Added instruction to read target repo's CLAUDE.md for project-specific conventions
- **lib/ocak/templates/ocak.yml.erb**: Added commented-out `multi_repo` and `target_field` configuration section
- **.claude/skills/design/SKILL.md**: Minor formatting fix

## Testing

Tests and linters were already verified by the implementer:
- `bundle exec rspec` — passed
- `bundle exec rubocop` — passed