### PR TITLE
fix: replace slashes with hyphens in generated branch names

### DIFF
--- a/lib/ocak/commands/hiz.rb
+++ b/lib/ocak/commands/hiz.rb
@@ -120,7 +120,7 @@ module Ocak
       end
 
       def create_branch(issue_number, chdir)
-        branch = "hiz/issue-#{issue_number}-#{SecureRandom.hex(4)}"
+        branch = "hiz-issue-#{issue_number}-#{SecureRandom.hex(4)}"
         raise "Unsafe branch name: #{branch}" unless GitUtils.safe_branch_name?(branch)
 
         result = run_git('checkout', '-b', branch, chdir: chdir)

--- a/lib/ocak/worktree_manager.rb
+++ b/lib/ocak/worktree_manager.rb
@@ -21,7 +21,7 @@ module Ocak
 
         FileUtils.mkdir_p(@worktree_base)
 
-        branch = "auto/issue-#{issue_number}-#{SecureRandom.hex(4)}"
+        branch = "auto-issue-#{issue_number}-#{SecureRandom.hex(4)}"
         path = File.join(@worktree_base, "issue-#{issue_number}")
 
         _, stderr, status = git('worktree', 'add', '-b', branch, path, 'main')

--- a/spec/ocak/commands/hiz_spec.rb
+++ b/spec/ocak/commands/hiz_spec.rb
@@ -91,11 +91,11 @@ RSpec.describe Ocak::Commands::Hiz do
               chdir: '/project', model: 'sonnet')
     end
 
-    it 'creates a branch with hiz/ prefix' do
+    it 'creates a branch with hiz- prefix' do
       command.call(issue: '42')
 
       expect(Open3).to have_received(:capture3)
-        .with('git', 'checkout', '-b', match(%r{\Ahiz/issue-42-[0-9a-f]{8}\z}), chdir: '/project')
+        .with('git', 'checkout', '-b', match(/\Ahiz-issue-42-[0-9a-f]{8}\z/), chdir: '/project')
     end
 
     it 'creates a PR via gh with issue title' do
@@ -105,7 +105,7 @@ RSpec.describe Ocak::Commands::Hiz do
         .with('gh', 'pr', 'create',
               '--title', 'Fix #42: Add fast mode',
               '--body', match(/Closes #42/),
-              '--head', match(%r{\Ahiz/issue-42-}),
+              '--head', match(/\Ahiz-issue-42-/),
               chdir: '/project')
     end
 
@@ -147,7 +147,7 @@ RSpec.describe Ocak::Commands::Hiz do
       command.call(issue: '42')
 
       expect(Open3).to have_received(:capture3)
-        .with('git', 'branch', '-D', match(%r{\Ahiz/issue-42-}), chdir: '/project')
+        .with('git', 'branch', '-D', match(/\Ahiz-issue-42-/), chdir: '/project')
     end
 
     it 'logs debug message when failure comment posting fails' do
@@ -295,7 +295,7 @@ RSpec.describe Ocak::Commands::Hiz do
       command.call(issue: '42')
 
       expect(Open3).to have_received(:capture3)
-        .with('git', 'branch', '-D', match(%r{\Ahiz/issue-42-}), chdir: '/project')
+        .with('git', 'branch', '-D', match(/\Ahiz-issue-42-/), chdir: '/project')
     end
   end
 
@@ -737,7 +737,7 @@ RSpec.describe Ocak::Commands::Hiz do
         .with(42, match(/failed at phase: create-branch/))
     end
 
-    it 'generates branch names matching hiz/issue-<N>-<hex8> format' do
+    it 'generates branch names matching hiz-issue-<N>-<hex8> format' do
       allow(claude).to receive(:run_agent).and_return(success_result)
       allow(issues).to receive(:view).with(42).and_return(nil)
       allow(Open3).to receive(:capture3)
@@ -748,7 +748,7 @@ RSpec.describe Ocak::Commands::Hiz do
       command.call(issue: '42')
 
       expect(Open3).to have_received(:capture3)
-        .with('git', 'checkout', '-b', match(%r{\Ahiz/issue-\d+-[0-9a-f]{8}\z}), chdir: '/project')
+        .with('git', 'checkout', '-b', match(/\Ahiz-issue-\d+-[0-9a-f]{8}\z/), chdir: '/project')
     end
   end
 

--- a/spec/ocak/worktree_manager_spec.rb
+++ b/spec/ocak/worktree_manager_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Ocak::WorktreeManager do
 
       worktree = manager.create(42)
 
-      expect(worktree.branch).to match(%r{\Aauto/issue-42-[a-f0-9]{8}\z})
+      expect(worktree.branch).to match(/\Aauto-issue-42-[a-f0-9]{8}\z/)
       expect(worktree.path).to eq('/project/.claude/worktrees/issue-42')
       expect(worktree.issue_number).to eq(42)
     end


### PR DESCRIPTION
## Summary
- Replace `auto/issue-` prefix with `auto-issue-` in worktree branch names
- Replace `hiz/issue-` prefix with `hiz-issue-` in hiz command branch names
- Update corresponding test assertions

## Test plan
- [x] All 1241 tests pass
- [x] Rubocop clean (110 files, no offenses)

🤖 Generated with [Claude Code](https://claude.com/claude-code)